### PR TITLE
:sparkles: Feat: 작품 좋아요 관련 기능 추가

### DIFF
--- a/src/main/java/com/likelion13/artium/domain/auth/dto/response/TokenResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/auth/dto/response/TokenResponse.java
@@ -1,0 +1,35 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.auth.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 토큰 응답 DTO
+ *
+ * <p>인증 및 토큰 갱신 시 응답으로 사용되는 DTO입니다.
+ *
+ * @author YFIVE
+ * @since 1.0.0
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "토큰 응답")
+public class TokenResponse {
+
+  @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+  private String accessToken;
+
+  @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+  private String refreshToken;
+
+  @Schema(description = "사용자 아이디", example = "홍길동")
+  private String username;
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/controller/ExhibitionController.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/controller/ExhibitionController.java
@@ -1,0 +1,51 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.likelion13.artium.domain.exhibition.dto.request.ExhibitionRequest;
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
+import com.likelion13.artium.global.page.response.PageResponse;
+import com.likelion13.artium.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "전시", description = "전시 관련 API")
+@RequestMapping("/api/exhibitions")
+public interface ExhibitionController {
+
+  @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @Operation(summary = "전시 등록", description = "작품 식별자 리스트 및 전시 정보를 요청 받아 사용자의 전시를 등록합니다.")
+  ResponseEntity<BaseResponse<String>> createExhibition(
+      @Parameter(
+              description = "전시 썸네일 이미지 파일",
+              content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+          @RequestPart(value = "image", required = false)
+          MultipartFile image,
+      @Parameter(
+              description = "전시 등록 요청 정보",
+              content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+          @Valid
+          @RequestPart(value = "request", required = false)
+          ExhibitionRequest request);
+
+  @GetMapping
+  @Operation(summary = "내 전시 리스트 조회", description = "사용자의 전시 리스트를 페이지로 반환합니다.")
+  ResponseEntity<BaseResponse<PageResponse<ExhibitionResponse>>> getExhibitionPage(
+      @Parameter(description = "페이지 번호", example = "1") @RequestParam Integer pageNum,
+      @Parameter(description = "페이지 크기", example = "3") @RequestParam Integer pageSize);
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/controller/ExhibitionControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/controller/ExhibitionControllerImpl.java
@@ -1,0 +1,54 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.controller;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.likelion13.artium.domain.exhibition.dto.request.ExhibitionRequest;
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
+import com.likelion13.artium.domain.exhibition.service.ExhibitionService;
+import com.likelion13.artium.global.exception.CustomException;
+import com.likelion13.artium.global.page.exception.PageErrorStatus;
+import com.likelion13.artium.global.page.response.PageResponse;
+import com.likelion13.artium.global.response.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ExhibitionControllerImpl implements ExhibitionController {
+
+  private final ExhibitionService exhibitionService;
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> createExhibition(
+      @RequestPart(required = false) MultipartFile image,
+      @RequestPart(required = false) ExhibitionRequest request) {
+
+    return ResponseEntity.ok(
+        BaseResponse.success(exhibitionService.createExhibition(image, request)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<PageResponse<ExhibitionResponse>>> getExhibitionPage(
+      @RequestParam Integer pageNum, @RequestParam Integer pageSize) {
+
+    if (pageNum < 1) {
+      throw new CustomException(PageErrorStatus.PAGE_NOT_FOUND);
+    }
+    if (pageSize < 1) {
+      throw new CustomException(PageErrorStatus.PAGE_SIZE_ERROR);
+    }
+
+    Pageable pageable = PageRequest.of(pageNum - 1, pageSize);
+
+    return ResponseEntity.ok(BaseResponse.success(exhibitionService.getExhibitionPage(pageable)));
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/dto/request/ExhibitionRequest.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/dto/request/ExhibitionRequest.java
@@ -1,0 +1,47 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.dto.request;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.likelion13.artium.domain.exhibition.entity.BankName;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "TraditionRequest DTO", description = "전통문화 생성을 위한 데이터 전송")
+public class ExhibitionRequest {
+
+  @Schema(description = "전시에 포함될 작품 ID 리스트", example = "[1, 2, 3]")
+  private List<Long> pieceIdList;
+
+  @Schema(description = "전시 제목", example = "성북구 신인 작가 합동 전시: 두 번째 여름")
+  private String title;
+
+  @Schema(description = "전시 설명", example = "이번 전시는 성북구의 신인 작가들이 모여서 개최한 전시이다.")
+  private String description;
+
+  @Schema(description = "시작일", example = "2025-01-01")
+  private LocalDate startDate;
+
+  @Schema(description = "종료일", example = "2025-12-31")
+  private LocalDate endDate;
+
+  @Schema(description = "오프라인 전시 주소", example = "남대문로 9길 40")
+  private String address;
+
+  @Schema(description = "거래 계좌번호", example = "93800200854555")
+  private String accountNumber;
+
+  @Schema(description = "거래 은행", example = "KOOKMIN")
+  private BankName bankName;
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/dto/response/ExhibitionResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/dto/response/ExhibitionResponse.java
@@ -1,0 +1,39 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.dto.response;
+
+import java.time.LocalDate;
+
+import com.likelion13.artium.domain.exhibition.entity.ExhibitionStatus;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "ExhibitionResponse DTO", description = "전시 정보 응답 반환")
+public class ExhibitionResponse {
+
+  @Schema(description = "전시 식별자", example = "1")
+  private Long exhibitionId;
+
+  @Schema(description = "썸네일 사진 URL", example = "")
+  private String thumbnailImageUrl;
+
+  @Schema(description = "전시 상태", example = "UPCOMING")
+  private ExhibitionStatus status;
+
+  @Schema(description = "전시 제목", example = "성북구 신인 작가 합동 전시: 두 번째 여름")
+  private String title;
+
+  @Schema(description = "시작일", example = "2025-01-01")
+  private LocalDate startDate;
+
+  @Schema(description = "종료일", example = "2025-12-31")
+  private LocalDate endDate;
+
+  @Schema(description = "오프라인 전시 주소", example = "남대문로 9길 40")
+  private String address;
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/entity/BankName.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/entity/BankName.java
@@ -1,0 +1,17 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public enum BankName {
+  @Schema(description = "국민은행")
+  KOOKMIN,
+  @Schema(description = "우리은행")
+  WOORI,
+  @Schema(description = "신한은행")
+  SHINHAN,
+  @Schema(description = "카카오뱅크")
+  KAKAO
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
@@ -1,0 +1,69 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.entity;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionUser;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "exhibition")
+public class Exhibition {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "thumbnail_image_url")
+  private String thumbnailImageUrl;
+
+  @Column(name = "title")
+  private String title;
+
+  @Column(name = "description")
+  private String description;
+
+  @Column(name = "start_date")
+  private LocalDate startDate;
+
+  @Column(name = "end_date")
+  private LocalDate endDate;
+
+  @Column(name = "address")
+  private String address;
+
+  @Column(name = "account_number")
+  private String accountNumber;
+
+  @Column(name = "bank_name")
+  private BankName bankName;
+
+  @Column(name = "status")
+  private ExhibitionStatus exhibitionStatus;
+
+  @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ExhibitionUser> exhibitionUsers = new ArrayList<>();
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/entity/ExhibitionStatus.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/entity/ExhibitionStatus.java
@@ -1,0 +1,15 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.entity;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public enum ExhibitionStatus {
+  @Schema(description = "전시예정")
+  UPCOMING,
+  @Schema(description = "전시중")
+  ONGOING,
+  @Schema(description = "전시종료")
+  ENDED
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/exception/ExhibitionErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/exception/ExhibitionErrorCode.java
@@ -1,0 +1,22 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.likelion13.artium.global.exception.model.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ExhibitionErrorCode implements BaseErrorCode {
+  INVALID_DATE_RANGE("EXHIBIT_4001", "유효하지 않은 날짜 요청입니다.", HttpStatus.BAD_REQUEST),
+  EXHIBITION_API_ERROR("EXHIITB_5001", "전시 API 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/mapper/ExhibitionMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/mapper/ExhibitionMapper.java
@@ -1,0 +1,42 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.likelion13.artium.domain.exhibition.dto.request.ExhibitionRequest;
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.exhibition.entity.ExhibitionStatus;
+
+@Component
+public class ExhibitionMapper {
+
+  public Exhibition toExhibition(
+      String imageUrl, ExhibitionRequest request, ExhibitionStatus status) {
+    return Exhibition.builder()
+        .thumbnailImageUrl(imageUrl)
+        .title(request.getTitle())
+        .description(request.getDescription())
+        .startDate(request.getStartDate())
+        .endDate(request.getEndDate())
+        .address(request.getAddress())
+        .accountNumber(request.getAccountNumber())
+        .bankName(request.getBankName())
+        .exhibitionStatus(status)
+        .build();
+  }
+
+  public ExhibitionResponse toExhibitionResponse(Exhibition exhibition) {
+    return ExhibitionResponse.builder()
+        .exhibitionId(exhibition.getId())
+        .thumbnailImageUrl(exhibition.getThumbnailImageUrl())
+        .status(exhibition.getExhibitionStatus())
+        .title(exhibition.getTitle())
+        .startDate(exhibition.getStartDate())
+        .endDate(exhibition.getEndDate())
+        .address(exhibition.getAddress())
+        .build();
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionUser.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionUser.java
@@ -1,0 +1,33 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.mapping;
+
+import jakarta.persistence.*;
+
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.global.common.BaseTimeEntity;
+
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "exhibition_user")
+public class ExhibitionUser extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "exhibition_id", nullable = false)
+  private Exhibition exhibition;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/repository/ExhibitionRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/repository/ExhibitionRepository.java
@@ -1,0 +1,21 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+
+import io.lettuce.core.dynamic.annotation.Param;
+
+@Repository
+public interface ExhibitionRepository extends JpaRepository<Exhibition, Long> {
+
+  @Query("SELECT e FROM Exhibition e JOIN e.exhibitionUsers eu WHERE eu.user.id = :userId")
+  Page<Exhibition> findByUserId(@Param("userId") Long userId, Pageable pageable);
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/service/ExhibitionService.java
@@ -1,0 +1,18 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.service;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.likelion13.artium.domain.exhibition.dto.request.ExhibitionRequest;
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
+import com.likelion13.artium.global.page.response.PageResponse;
+
+public interface ExhibitionService {
+
+  String createExhibition(MultipartFile image, ExhibitionRequest request);
+
+  PageResponse<ExhibitionResponse> getExhibitionPage(Pageable pageable);
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/service/ExhibitionServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/service/ExhibitionServiceImpl.java
@@ -1,0 +1,98 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.exhibition.service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.likelion13.artium.domain.exhibition.dto.request.ExhibitionRequest;
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.exhibition.entity.ExhibitionStatus;
+import com.likelion13.artium.domain.exhibition.exception.ExhibitionErrorCode;
+import com.likelion13.artium.domain.exhibition.mapper.ExhibitionMapper;
+import com.likelion13.artium.domain.exhibition.repository.ExhibitionRepository;
+import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.domain.user.service.UserService;
+import com.likelion13.artium.global.exception.CustomException;
+import com.likelion13.artium.global.page.mapper.PageMapper;
+import com.likelion13.artium.global.page.response.PageResponse;
+import com.likelion13.artium.global.s3.entity.PathName;
+import com.likelion13.artium.global.s3.service.S3Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ExhibitionServiceImpl implements ExhibitionService {
+
+  private final ExhibitionRepository exhibitionRepository;
+  private final UserService userService;
+  private final S3Service s3Service;
+  private final ExhibitionMapper exhibitionMapper;
+  private final PageMapper pageMapper;
+
+  @Override
+  @Transactional
+  public String createExhibition(MultipartFile image, ExhibitionRequest request) {
+
+    if (request.getStartDate().isAfter(request.getEndDate())) {
+      throw new CustomException(ExhibitionErrorCode.INVALID_DATE_RANGE);
+    }
+
+    String imageUrl = null;
+    ExhibitionStatus status = ExhibitionStatus.UPCOMING;
+    LocalDate now = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+    if (image != null) {
+      imageUrl = s3Service.uploadFile(PathName.EXHIBITION, image);
+    }
+
+    if (request.getEndDate().isBefore(now) || request.getEndDate().isEqual(now)) {
+      status = ExhibitionStatus.ENDED;
+    } else if (request.getStartDate().isBefore(now) || request.getStartDate().isEqual(now)) {
+      status = ExhibitionStatus.ONGOING;
+    }
+
+    Exhibition exhibition = exhibitionMapper.toExhibition(imageUrl, request, status);
+
+    try {
+      exhibitionRepository.save(exhibition);
+    } catch (Exception e) {
+      s3Service.deleteFile(s3Service.extractKeyNameFromUrl(imageUrl));
+      throw new CustomException(ExhibitionErrorCode.EXHIBITION_API_ERROR);
+    }
+    log.info("전시 정보 생성 성공 - id:{}, imageUrl:{}, status:{}", exhibition.getId(), imageUrl, status);
+
+    return exhibition.getId().toString() + "번 식별자의 전시가 성공적으로 생성되었습니다.";
+  }
+
+  @Override
+  public PageResponse<ExhibitionResponse> getExhibitionPage(Pageable pageable) {
+    User user = userService.getCurrentUser();
+
+    Pageable sortedPageable =
+        PageRequest.of(
+            pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Direction.DESC, "startDate"));
+
+    Page<ExhibitionResponse> page =
+        exhibitionRepository
+            .findByUserId(user.getId(), sortedPageable)
+            .map(exhibitionMapper::toExhibitionResponse);
+
+    log.info("{} 사용자의 전시 리스트 페이지 조회 - 호출된 페이지: {}", user.getNickname(), pageable.getPageNumber());
+    return pageMapper.toExhibitionPageResponse(page);
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceController.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceController.java
@@ -34,14 +34,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "Piece", description = "Piece(작품) 관리 API")
 public interface PieceController {
 
-  @Operation(summary = "내 작품 리스트 조회 API", description = "전시장 메인 페이지에서 내 작품 리스트를 조회하기 위한 API")
+  @Operation(
+      summary = "내 작품 리스트 조회 API (로그인 필요)",
+      description = "전시장 메인 페이지에서 내 작품 리스트를 조회하기 위한 API")
   @GetMapping()
   ResponseEntity<BaseResponse<List<PieceSummaryResponse>>> getPieces(
       @AuthenticationPrincipal CustomUserDetails userDetails);
 
-  @Operation(summary = "내 작품 정보 등록하기 API", description = "내 작품 정보 등록에서 작품을 등록하기 위한 API")
+  @Operation(summary = "내 작품 정보 등록하기 API (로그인 필요)", description = "내 작품 정보 등록에서 작품을 등록하기 위한 API")
   @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-  ResponseEntity<BaseResponse<PieceResponse>> createPiece(
+  ResponseEntity<BaseResponse<PieceSummaryResponse>> createPiece(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Parameter(description = "작품 등록 내용") @RequestPart("data") @Valid
           CreatePieceRequest createPieceRequest,
@@ -51,14 +53,16 @@ public interface PieceController {
           List<MultipartFile> detailImages);
 
   @Operation(
-      summary = "특정 작품 정보 조회하기 API",
+      summary = "특정 작품 정보 조회하기 API (로그인 필요)",
       description = "특정 작품 정보 수정 및 작품 상세 정보에서 작품 정보를 조회하기 위한 API")
   @GetMapping("/{piece-id}")
   ResponseEntity<BaseResponse<PieceResponse>> getPiece(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId);
 
-  @Operation(summary = "특정 작품 정보 수정하기 API", description = "특정 작품 정보 수정에서 작품 정보를 수정하기 위한 API")
+  @Operation(
+      summary = "특정 작품 정보 수정하기 API (로그인 필요)",
+      description = "특정 작품 정보 수정에서 작품 정보를 수정하기 위한 API")
   @PutMapping(value = "/{piece-id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   ResponseEntity<BaseResponse<PieceResponse>> updatePiece(
       @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
@@ -70,7 +74,9 @@ public interface PieceController {
       @Parameter(description = "작품 디테일 컷 모음") @RequestPart(value = "detailImages", required = false)
           List<MultipartFile> detailImages);
 
-  @Operation(summary = "특정 작품 삭제하기 API", description = "특정 작품 정보 또는 작품 임시저장에서 작품을 삭제하기 위한 API")
+  @Operation(
+      summary = "특정 작품 삭제하기 API (로그인 필요)",
+      description = "특정 작품 정보 또는 작품 임시저장에서 작품을 삭제하기 위한 API")
   @DeleteMapping("/{piece-id}")
   ResponseEntity<BaseResponse<String>> deletePiece(
       @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
@@ -42,17 +42,18 @@ public class PieceControllerImpl implements PieceController {
   }
 
   @Override
-  public ResponseEntity<BaseResponse<PieceResponse>> createPiece(
+  public ResponseEntity<BaseResponse<PieceSummaryResponse>> createPiece(
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestPart("data") @Valid CreatePieceRequest createPieceRequest,
       @RequestPart(value = "mainImage", required = false) MultipartFile mainImage,
       @RequestPart(value = "detailImages", required = false) List<MultipartFile> detailImages) {
+
     if (detailImages != null && detailImages.size() > 5)
       throw new CustomException(PieceErrorCode.TOO_MANY_DETAIL_IMAGES);
-    PieceResponse pieceResponse =
+    PieceSummaryResponse pieceSummaryResponse =
         pieceService.createPiece(userDetails, createPieceRequest, mainImage, detailImages);
 
-    return ResponseEntity.ok(BaseResponse.success("작품 등록에 성공했습니다.", pieceResponse));
+    return ResponseEntity.ok(BaseResponse.success("작품 등록에 성공했습니다.", pieceSummaryResponse));
   }
 
   @Override
@@ -72,12 +73,14 @@ public class PieceControllerImpl implements PieceController {
       @RequestPart("data") @Valid UpdatePieceRequest updatePieceRequest,
       @RequestPart(value = "mainImage", required = false) MultipartFile mainImage,
       @RequestPart(value = "detailImages", required = false) List<MultipartFile> detailImages) {
-    if (detailImages != null && detailImages.size() > 5)
+
+    if (detailImages != null
+        && updatePieceRequest.getRemainPieceDetailIds().size() + detailImages.size() > 5)
       throw new CustomException(PieceErrorCode.TOO_MANY_DETAIL_IMAGES);
     PieceResponse pieceResponse =
         pieceService.updatePiece(userDetails, pieceId, updatePieceRequest, mainImage, detailImages);
 
-    return ResponseEntity.ok(BaseResponse.success("작품 수정에 성공했습니다,", pieceResponse));
+    return ResponseEntity.ok(BaseResponse.success("작품 수정에 성공했습니다.", pieceResponse));
   }
 
   @Override

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
@@ -74,8 +74,9 @@ public class PieceControllerImpl implements PieceController {
       @RequestPart(value = "mainImage", required = false) MultipartFile mainImage,
       @RequestPart(value = "detailImages", required = false) List<MultipartFile> detailImages) {
 
+    int remainCount = updatePieceRequest.getRemainPieceDetailIds() == null ? 0 : updatePieceRequest.getRemainPieceDetailIds().size();
     if (detailImages != null
-        && updatePieceRequest.getRemainPieceDetailIds().size() + detailImages.size() > 5)
+        && remainCount + detailImages.size() > 5)
       throw new CustomException(PieceErrorCode.TOO_MANY_DETAIL_IMAGES);
     PieceResponse pieceResponse =
         pieceService.updatePiece(userDetails, pieceId, updatePieceRequest, mainImage, detailImages);

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
@@ -74,9 +74,11 @@ public class PieceControllerImpl implements PieceController {
       @RequestPart(value = "mainImage", required = false) MultipartFile mainImage,
       @RequestPart(value = "detailImages", required = false) List<MultipartFile> detailImages) {
 
-    int remainCount = updatePieceRequest.getRemainPieceDetailIds() == null ? 0 : updatePieceRequest.getRemainPieceDetailIds().size();
-    if (detailImages != null
-        && remainCount + detailImages.size() > 5)
+    int remainCount =
+        updatePieceRequest.getRemainPieceDetailIds() == null
+            ? 0
+            : updatePieceRequest.getRemainPieceDetailIds().size();
+    if (detailImages != null && remainCount + detailImages.size() > 5)
       throw new CustomException(PieceErrorCode.TOO_MANY_DETAIL_IMAGES);
     PieceResponse pieceResponse =
         pieceService.updatePiece(userDetails, pieceId, updatePieceRequest, mainImage, detailImages);

--- a/src/main/java/com/likelion13/artium/domain/piece/dto/response/PieceResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/dto/response/PieceResponse.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 @Schema(title = "PieceResponse DTO", description = "작품에 대한 응답 반환(디테일 컷 리스트 포함)")
 public class PieceResponse {
 
-  @Schema(description = "작품 아이디", example = "1")
+  @Schema(description = "작품 식별자", example = "1")
   private Long pieceId;
 
   @Schema(description = "작품 제목", example = "제주도의 집")
@@ -40,4 +40,8 @@ public class PieceResponse {
 
   @Schema(description = "디테일 컷 리스트")
   private List<PieceDetailSummaryResponse> pieceDetails;
+
+  @Schema(description = "요청 사용자의 좋아요 여부", example = "false")
+  @Builder.Default
+  private Boolean isLike = false;
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/dto/response/PieceSummaryResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/dto/response/PieceSummaryResponse.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 @Schema(title = "PieceSummaryResponse DTO", description = "작품에 대한 응답 반환(디테일 컷 리스트 미포함)")
 public class PieceSummaryResponse {
 
-  @Schema(description = "작품 아이디", example = "1")
+  @Schema(description = "작품 식별자", example = "1")
   private Long pieceId;
 
   @Schema(description = "작품 제목", example = "제주도의 집")

--- a/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
@@ -21,6 +21,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import com.likelion13.artium.domain.pieceDetail.entity.PieceDetail;
+import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 import com.likelion13.artium.domain.user.entity.User;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
@@ -57,14 +58,20 @@ public class Piece extends BaseTimeEntity {
 
   @Enumerated(EnumType.STRING)
   @Column(name = "status", nullable = false)
+  @Builder.Default
   private Status status = Status.UNREGISTERED;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
   @OneToMany(mappedBy = "piece", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
   private List<PieceDetail> pieceDetails = new ArrayList<>();
+
+  @OneToMany(mappedBy = "piece", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<PieceLike> pieceLikes = new ArrayList<>();
 
   public void update(String title, String description, Boolean isPurchasable, Status status) {
     this.title = title;
@@ -79,14 +86,9 @@ public class Piece extends BaseTimeEntity {
     return oldImageUrl;
   }
 
-  public void updatePieceDetails(List<PieceDetail> pieceDetails) {
-    if (pieceDetails == null) return;
-    this.pieceDetails = pieceDetails;
-  }
-
   public void addPieceDetail(PieceDetail pieceDetail) {
     if (pieceDetail == null) return;
-    if (this.pieceDetails == null) this.pieceDetails = new ArrayList<>();
-    this.pieceDetails.add(pieceDetail);
+    if (this.pieceDetails == null) pieceDetails = new ArrayList<>();
+    pieceDetails.add(pieceDetail);
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
@@ -30,6 +30,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter

--- a/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
@@ -30,7 +30,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.BatchSize;
 
 @Entity
 @Getter

--- a/src/main/java/com/likelion13/artium/domain/piece/exception/PieceErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/exception/PieceErrorCode.java
@@ -16,7 +16,7 @@ public enum PieceErrorCode implements BaseErrorCode {
   UNAUTHORIZED("PIECE_4031", "작품에 대한 접근 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
   PIECE_NOT_FOUND("PIECE_4041", "존재하지 않는 작품입니다.", HttpStatus.NOT_FOUND),
   TOO_MANY_DETAIL_IMAGES("PIECE_4001", "디테일 이미지는 최대 5개까지 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
-  DETAIL_IMAGE_NOT_BELONG_TO_PIECE("PIECE_4032", "해당 작품의 디테일 이미지가 아닙니다.", HttpStatus.FORBIDDEN);
+  DETAIL_IMAGE_NOT_BELONG_TO_PIECE("PIECE_4002", "해당 작품의 디테일 이미지가 아닙니다.", HttpStatus.BAD_REQUEST);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/likelion13/artium/domain/piece/exception/PieceErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/exception/PieceErrorCode.java
@@ -15,7 +15,8 @@ import lombok.Getter;
 public enum PieceErrorCode implements BaseErrorCode {
   UNAUTHORIZED("PIECE_4031", "작품에 대한 접근 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
   PIECE_NOT_FOUND("PIECE_4041", "존재하지 않는 작품입니다.", HttpStatus.NOT_FOUND),
-  TOO_MANY_DETAIL_IMAGES("PIECE_4001", "디테일 이미지는 최대 5개까지 업로드 가능합니다.", HttpStatus.BAD_REQUEST);
+  TOO_MANY_DETAIL_IMAGES("PIECE_4001", "디테일 이미지는 최대 5개까지 업로드 가능합니다.", HttpStatus.BAD_REQUEST),
+  DETAIL_IMAGE_NOT_BELONG_TO_PIECE("PIECE_4032", "해당 작품의 디테일 이미지가 아닙니다.", HttpStatus.FORBIDDEN);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
@@ -21,24 +21,16 @@ public class PieceMapper {
   private final PieceDetailMapper pieceDetailMapper;
 
   public PieceResponse toPieceResponse(Piece piece) {
-    return PieceResponse.builder()
-        .pieceId(piece.getId())
-        .title(piece.getTitle())
-        .description(piece.getDescription())
-        .imageUrl(piece.getImageUrl())
-        .isPurchasable(piece.getIsPurchasable())
-        .status(piece.getStatus())
-        .userId(piece.getUser().getId())
-        .pieceDetails(
-            piece.getPieceDetails() == null
-                ? List.of()
-                : piece.getPieceDetails().stream()
-                    .map(pieceDetailMapper::toPieceDetailSummaryResponse)
-                    .toList())
+    return toPieceResponseWithLike(piece, null);
+  }
+
+  public PieceResponse toPieceResponseWithLike(Piece piece, Boolean isLike) {
+    return buildBasePieceResponse(piece)
+        .isLike(isLike)
         .build();
   }
 
-  public PieceResponse toPieceResponseWithLike(Piece piece, Boolean isLiked) {
+  private PieceResponse.PieceResponseBuilder buildBasePieceResponse(Piece piece) {
     return PieceResponse.builder()
         .pieceId(piece.getId())
         .title(piece.getTitle())
@@ -52,9 +44,7 @@ public class PieceMapper {
                 ? List.of()
                 : piece.getPieceDetails().stream()
                     .map(pieceDetailMapper::toPieceDetailSummaryResponse)
-                    .toList())
-        .isLike(isLiked)
-        .build();
+                    .toList());
   }
 
   public PieceSummaryResponse toPieceSummaryResponse(Piece piece) {

--- a/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
@@ -33,8 +33,27 @@ public class PieceMapper {
             piece.getPieceDetails() == null
                 ? List.of()
                 : piece.getPieceDetails().stream()
-                    .map(pieceDetail -> pieceDetailMapper.toPieceDetailSummaryResponse(pieceDetail))
+                    .map(pieceDetailMapper::toPieceDetailSummaryResponse)
                     .toList())
+        .build();
+  }
+
+  public PieceResponse toPieceResponseWithLike(Piece piece, Boolean isLiked) {
+    return PieceResponse.builder()
+        .pieceId(piece.getId())
+        .title(piece.getTitle())
+        .description(piece.getDescription())
+        .imageUrl(piece.getImageUrl())
+        .isPurchasable(piece.getIsPurchasable())
+        .status(piece.getStatus())
+        .userId(piece.getUser().getId())
+        .pieceDetails(
+            piece.getPieceDetails() == null
+                ? List.of()
+                : piece.getPieceDetails().stream()
+                    .map(pieceDetailMapper::toPieceDetailSummaryResponse)
+                    .toList())
+        .isLike(isLiked)
         .build();
   }
 

--- a/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
@@ -25,9 +25,7 @@ public class PieceMapper {
   }
 
   public PieceResponse toPieceResponseWithLike(Piece piece, Boolean isLike) {
-    return buildBasePieceResponse(piece)
-        .isLike(isLike)
-        .build();
+    return buildBasePieceResponse(piece).isLike(isLike).build();
   }
 
   private PieceResponse.PieceResponseBuilder buildBasePieceResponse(Piece piece) {

--- a/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
@@ -5,6 +5,7 @@ package com.likelion13.artium.domain.piece.repository;
 
 import java.util.List;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.likelion13.artium.domain.piece.entity.Piece;
@@ -12,4 +13,5 @@ import com.likelion13.artium.domain.piece.entity.Piece;
 public interface PieceRepository extends JpaRepository<Piece, Long> {
 
   List<Piece> findAllByUser_IdOrderByCreatedAtDesc(Long userId);
+
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
@@ -5,7 +5,6 @@ package com.likelion13.artium.domain.piece.repository;
 
 import java.util.List;
 
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.likelion13.artium.domain.piece.entity.Piece;
@@ -13,5 +12,4 @@ import com.likelion13.artium.domain.piece.entity.Piece;
 public interface PieceRepository extends JpaRepository<Piece, Long> {
 
   List<Piece> findAllByUser_IdOrderByCreatedAtDesc(Long userId);
-
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/service/PieceService.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/service/PieceService.java
@@ -28,7 +28,7 @@ public interface PieceService {
    * @param detailImages 작품 디테일 컷들 (S3 업로드 로직, 없는 경우 처리 로직 포함)
    * @return 작품 정보 응답
    */
-  PieceResponse createPiece(
+  PieceSummaryResponse createPiece(
       CustomUserDetails userDetails,
       CreatePieceRequest createPieceRequest,
       MultipartFile mainImage,

--- a/src/main/java/com/likelion13/artium/domain/pieceDetail/entity/PieceDetail.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceDetail/entity/PieceDetail.java
@@ -39,6 +39,6 @@ public class PieceDetail extends BaseTimeEntity {
   private String imageUrl;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "piece_id")
+  @JoinColumn(name = "piece_id", nullable = false)
   private Piece piece;
 }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeController.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeController.java
@@ -1,0 +1,36 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
+import com.likelion13.artium.global.response.BaseResponse;
+import com.likelion13.artium.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RequestMapping("/api/pieces")
+@Tag(name = "Piece Like", description = "Piece Like(작품 좋아요) 관리 API")
+public interface PieceLikeController {
+
+  @Operation(summary = "특정 작품 좋아요 등록하기 API (로그인 필요)", description = "특정 작품 정보에서 좋아요를 등록하기 위한 API")
+  @PostMapping("/{piece-id}/likes")
+  ResponseEntity<BaseResponse<PieceLikeResponse>> likePiece(
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
+      @AuthenticationPrincipal CustomUserDetails userDetails);
+
+  @Operation(summary = "특정 작품 좋아요 취소하기 API (로그인 필요)", description = "특정 작품 정보에서 좋아요를 취소하기 위한 API")
+  @DeleteMapping("/{piece-id}/likes")
+  ResponseEntity<BaseResponse<PieceLikeResponse>> unlikePiece(
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
+      @AuthenticationPrincipal CustomUserDetails userDetails);
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeController.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeController.java
@@ -4,7 +4,6 @@
 package com.likelion13.artium.domain.pieceLike.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
 import com.likelion13.artium.global.response.BaseResponse;
-import com.likelion13.artium.global.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -25,12 +23,10 @@ public interface PieceLikeController {
   @Operation(summary = "특정 작품 좋아요 등록하기 API (로그인 필요)", description = "특정 작품 정보에서 좋아요를 등록하기 위한 API")
   @PostMapping("/{piece-id}/likes")
   ResponseEntity<BaseResponse<PieceLikeResponse>> likePiece(
-      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
-      @AuthenticationPrincipal CustomUserDetails userDetails);
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId);
 
   @Operation(summary = "특정 작품 좋아요 취소하기 API (로그인 필요)", description = "특정 작품 정보에서 좋아요를 취소하기 위한 API")
   @DeleteMapping("/{piece-id}/likes")
   ResponseEntity<BaseResponse<PieceLikeResponse>> unlikePiece(
-      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
-      @AuthenticationPrincipal CustomUserDetails userDetails);
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId);
 }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeControllerImpl.java
@@ -4,14 +4,12 @@
 package com.likelion13.artium.domain.pieceLike.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
 import com.likelion13.artium.domain.pieceLike.service.PieceLikeService;
 import com.likelion13.artium.global.response.BaseResponse;
-import com.likelion13.artium.global.security.CustomUserDetails;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -24,20 +22,18 @@ public class PieceLikeControllerImpl implements PieceLikeController {
 
   @Override
   public ResponseEntity<BaseResponse<PieceLikeResponse>> likePiece(
-      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId) {
 
-    PieceLikeResponse pieceLikeResponse = pieceLikeService.likePiece(userDetails, pieceId);
+    PieceLikeResponse pieceLikeResponse = pieceLikeService.likePiece(pieceId);
 
     return ResponseEntity.ok(BaseResponse.success("작품 좋아요 등록에 성공했습니다.", pieceLikeResponse));
   }
 
   @Override
   public ResponseEntity<BaseResponse<PieceLikeResponse>> unlikePiece(
-      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId) {
 
-    PieceLikeResponse pieceLikeResponse = pieceLikeService.unlikePiece(userDetails, pieceId);
+    PieceLikeResponse pieceLikeResponse = pieceLikeService.unlikePiece(pieceId);
 
     return ResponseEntity.ok(BaseResponse.success("작품 좋아요 취소에 성공했습니다.", pieceLikeResponse));
   }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeControllerImpl.java
@@ -1,0 +1,44 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
+import com.likelion13.artium.domain.pieceLike.service.PieceLikeService;
+import com.likelion13.artium.global.response.BaseResponse;
+import com.likelion13.artium.global.security.CustomUserDetails;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class PieceLikeControllerImpl implements PieceLikeController {
+
+  private final PieceLikeService pieceLikeService;
+
+  @Override
+  public ResponseEntity<BaseResponse<PieceLikeResponse>> likePiece(
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    PieceLikeResponse pieceLikeResponse = pieceLikeService.likePiece(userDetails, pieceId);
+
+    return ResponseEntity.ok(BaseResponse.success("작품 좋아요 등록에 성공했습니다.", pieceLikeResponse));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<PieceLikeResponse>> unlikePiece(
+      @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+    PieceLikeResponse pieceLikeResponse = pieceLikeService.unlikePiece(userDetails, pieceId);
+
+    return ResponseEntity.ok(BaseResponse.success("작품 좋아요 취소에 성공했습니다.", pieceLikeResponse));
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/dto/response/PieceLikeResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/dto/response/PieceLikeResponse.java
@@ -1,0 +1,20 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "PieceLikeResponse DTO", description = "작품 좋아요 관련 응답 반환 DTO")
+public class PieceLikeResponse {
+
+  @Schema(description = "작품 식별자", example = "1")
+  private Long pieceId;
+
+  @Schema(description = "좋아요 여부", example = "true")
+  private Boolean isLiked;
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/dto/response/PieceLikeResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/dto/response/PieceLikeResponse.java
@@ -16,5 +16,5 @@ public class PieceLikeResponse {
   private Long pieceId;
 
   @Schema(description = "좋아요 여부", example = "true")
-  private Boolean isLiked;
+  private Boolean isLike;
 }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/entity/PieceLike.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/entity/PieceLike.java
@@ -3,6 +3,7 @@
  */
 package com.likelion13.artium.domain.pieceLike.entity;
 
+import com.likelion13.artium.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -35,7 +36,7 @@ import lombok.NoArgsConstructor;
           name = "uq_piece_like_piece_user",
           columnNames = {"piece_id", "user_id"})
     })
-public class PieceLike {
+public class PieceLike extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/entity/PieceLike.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/entity/PieceLike.java
@@ -3,7 +3,6 @@
  */
 package com.likelion13.artium.domain.pieceLike.entity;
 
-import com.likelion13.artium.global.common.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -17,6 +16,7 @@ import jakarta.persistence.UniqueConstraint;
 
 import com.likelion13.artium.domain.piece.entity.Piece;
 import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.global.common.BaseTimeEntity;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/entity/PieceLike.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/entity/PieceLike.java
@@ -1,0 +1,52 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.domain.user.entity.User;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(
+    name = "piece_like",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uq_piece_like_piece_user",
+          columnNames = {"piece_id", "user_id"})
+    })
+public class PieceLike {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "piece_id", nullable = false)
+  private Piece piece;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/exception/PieceLikeErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/exception/PieceLikeErrorCode.java
@@ -1,0 +1,22 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.likelion13.artium.global.exception.model.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PieceLikeErrorCode implements BaseErrorCode {
+  ALREADY_LIKED("PIECE_LIKE_4091", "이미 좋아요 상태입니다.", HttpStatus.CONFLICT),
+  NOT_LIKED("PIECE_LIKE_4092", "좋아요한 상태가 아닙니다.", HttpStatus.CONFLICT);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/mapper/PieceLikeMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/mapper/PieceLikeMapper.java
@@ -1,0 +1,16 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
+
+@Component
+public class PieceLikeMapper {
+
+  public PieceLikeResponse toPieceLikeResponse(Long pieceId, Boolean isLike) {
+    return PieceLikeResponse.builder().pieceId(pieceId).isLiked(isLike).build();
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/mapper/PieceLikeMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/mapper/PieceLikeMapper.java
@@ -11,6 +11,6 @@ import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
 public class PieceLikeMapper {
 
   public PieceLikeResponse toPieceLikeResponse(Long pieceId, Boolean isLike) {
-    return PieceLikeResponse.builder().pieceId(pieceId).isLiked(isLike).build();
+    return PieceLikeResponse.builder().pieceId(pieceId).isLike(isLike).build();
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/repository/PieceLikeRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/repository/PieceLikeRepository.java
@@ -1,0 +1,15 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
+
+public interface PieceLikeRepository extends JpaRepository<PieceLike, Long> {
+
+  Optional<PieceLike> findByUser_IdAndPiece_Id(Long userId, Long pieceId);
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeService.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeService.java
@@ -1,0 +1,24 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.service;
+
+import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
+import com.likelion13.artium.global.security.CustomUserDetails;
+
+public interface PieceLikeService {
+
+  /**
+   * @param userDetails 요청 유저 정보
+   * @param pieceId 작품 식별자
+   * @return 작품 좋아요 정보 응답
+   */
+  PieceLikeResponse likePiece(CustomUserDetails userDetails, Long pieceId);
+
+  /**
+   * @param userDetails 요청 유저 정보
+   * @param pieceId 작품 식별자
+   * @return 작품 좋아요 정보 응답
+   */
+  PieceLikeResponse unlikePiece(CustomUserDetails userDetails, Long pieceId);
+}

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeService.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeService.java
@@ -4,21 +4,18 @@
 package com.likelion13.artium.domain.pieceLike.service;
 
 import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
-import com.likelion13.artium.global.security.CustomUserDetails;
 
 public interface PieceLikeService {
 
   /**
-   * @param userDetails 요청 유저 정보
    * @param pieceId 작품 식별자
    * @return 작품 좋아요 정보 응답
    */
-  PieceLikeResponse likePiece(CustomUserDetails userDetails, Long pieceId);
+  PieceLikeResponse likePiece(Long pieceId);
 
   /**
-   * @param userDetails 요청 유저 정보
    * @param pieceId 작품 식별자
    * @return 작품 좋아요 정보 응답
    */
-  PieceLikeResponse unlikePiece(CustomUserDetails userDetails, Long pieceId);
+  PieceLikeResponse unlikePiece(Long pieceId);
 }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
@@ -3,9 +3,6 @@
  */
 package com.likelion13.artium.domain.pieceLike.service;
 
-import com.likelion13.artium.domain.user.exception.UserErrorCode;
-import java.util.Optional;
-
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +16,7 @@ import com.likelion13.artium.domain.pieceLike.exception.PieceLikeErrorCode;
 import com.likelion13.artium.domain.pieceLike.mapper.PieceLikeMapper;
 import com.likelion13.artium.domain.pieceLike.repository.PieceLikeRepository;
 import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.domain.user.exception.UserErrorCode;
 import com.likelion13.artium.domain.user.repository.UserRepository;
 import com.likelion13.artium.global.exception.CustomException;
 import com.likelion13.artium.global.security.CustomUserDetails;
@@ -39,8 +37,10 @@ public class PieceLikeServiceImpl implements PieceLikeService {
   @Override
   @Transactional
   public PieceLikeResponse likePiece(CustomUserDetails userDetails, Long pieceId) {
-    User user = userRepository.findById(userDetails.getUser().getId()).orElseThrow(
-        () -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+    User user =
+        userRepository
+            .findById(userDetails.getUser().getId())
+            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
 
     Piece piece =
         pieceRepository
@@ -51,7 +51,7 @@ public class PieceLikeServiceImpl implements PieceLikeService {
 
       pieceLikeRepository.save(pieceLike);
     } catch (DataIntegrityViolationException e) {
-      if(e.getMessage() != null && e.getMessage().contains("uq_piece_like_piece_user")) {
+      if (e.getMessage() != null && e.getMessage().contains("uq_piece_like_piece_user")) {
         throw new CustomException(PieceLikeErrorCode.ALREADY_LIKED);
       }
       throw e;
@@ -67,8 +67,10 @@ public class PieceLikeServiceImpl implements PieceLikeService {
         .findById(pieceId)
         .orElseThrow(() -> new CustomException(PieceErrorCode.PIECE_NOT_FOUND));
 
-    PieceLike pieceLike = pieceLikeRepository.findByUser_IdAndPiece_Id(userDetails.getUser().getId(), pieceId)
-        .orElseThrow(() -> new CustomException(PieceLikeErrorCode.NOT_LIKED));
+    PieceLike pieceLike =
+        pieceLikeRepository
+            .findByUser_IdAndPiece_Id(userDetails.getUser().getId(), pieceId)
+            .orElseThrow(() -> new CustomException(PieceLikeErrorCode.NOT_LIKED));
     pieceLikeRepository.delete(pieceLike);
 
     return pieceLikeMapper.toPieceLikeResponse(pieceId, false);

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
@@ -16,10 +16,9 @@ import com.likelion13.artium.domain.pieceLike.exception.PieceLikeErrorCode;
 import com.likelion13.artium.domain.pieceLike.mapper.PieceLikeMapper;
 import com.likelion13.artium.domain.pieceLike.repository.PieceLikeRepository;
 import com.likelion13.artium.domain.user.entity.User;
-import com.likelion13.artium.domain.user.exception.UserErrorCode;
 import com.likelion13.artium.domain.user.repository.UserRepository;
+import com.likelion13.artium.domain.user.service.UserService;
 import com.likelion13.artium.global.exception.CustomException;
-import com.likelion13.artium.global.security.CustomUserDetails;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,14 +32,13 @@ public class PieceLikeServiceImpl implements PieceLikeService {
   private final UserRepository userRepository;
   private final PieceLikeMapper pieceLikeMapper;
   private final PieceLikeRepository pieceLikeRepository;
+  private final UserService userService;
 
   @Override
   @Transactional
-  public PieceLikeResponse likePiece(CustomUserDetails userDetails, Long pieceId) {
-    User user =
-        userRepository
-            .findById(userDetails.getUser().getId())
-            .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+  public PieceLikeResponse likePiece(Long pieceId) {
+
+    User user = userService.getCurrentUser();
 
     Piece piece =
         pieceRepository
@@ -62,14 +60,17 @@ public class PieceLikeServiceImpl implements PieceLikeService {
 
   @Override
   @Transactional
-  public PieceLikeResponse unlikePiece(CustomUserDetails userDetails, Long pieceId) {
+  public PieceLikeResponse unlikePiece(Long pieceId) {
+
+    User user = userService.getCurrentUser();
+
     pieceRepository
         .findById(pieceId)
         .orElseThrow(() -> new CustomException(PieceErrorCode.PIECE_NOT_FOUND));
 
     PieceLike pieceLike =
         pieceLikeRepository
-            .findByUser_IdAndPiece_Id(userDetails.getUser().getId(), pieceId)
+            .findByUser_IdAndPiece_Id(user.getId(), pieceId)
             .orElseThrow(() -> new CustomException(PieceLikeErrorCode.NOT_LIKED));
     pieceLikeRepository.delete(pieceLike);
 

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
@@ -1,0 +1,74 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.pieceLike.service;
+
+import java.util.Optional;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.domain.piece.exception.PieceErrorCode;
+import com.likelion13.artium.domain.piece.repository.PieceRepository;
+import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
+import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
+import com.likelion13.artium.domain.pieceLike.exception.PieceLikeErrorCode;
+import com.likelion13.artium.domain.pieceLike.mapper.PieceLikeMapper;
+import com.likelion13.artium.domain.pieceLike.repository.PieceLikeRepository;
+import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.domain.user.repository.UserRepository;
+import com.likelion13.artium.global.exception.CustomException;
+import com.likelion13.artium.global.security.CustomUserDetails;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class PieceLikeServiceImpl implements PieceLikeService {
+
+  private final PieceRepository pieceRepository;
+  private final UserRepository userRepository;
+  private final PieceLikeMapper pieceLikeMapper;
+  private final PieceLikeRepository pieceLikeRepository;
+
+  @Override
+  @Transactional
+  public PieceLikeResponse likePiece(CustomUserDetails userDetails, Long pieceId) {
+    User user = userRepository.getReferenceById(userDetails.getUser().getId());
+
+    Piece piece =
+        pieceRepository
+            .findById(pieceId)
+            .orElseThrow(() -> new CustomException(PieceErrorCode.PIECE_NOT_FOUND));
+    try {
+      PieceLike pieceLike = PieceLike.builder().piece(piece).user(user).build();
+
+      pieceLikeRepository.save(pieceLike);
+    } catch (DataIntegrityViolationException e) {
+      throw new CustomException(PieceLikeErrorCode.ALREADY_LIKED);
+    }
+
+    return pieceLikeMapper.toPieceLikeResponse(pieceId, true);
+  }
+
+  @Override
+  @Transactional
+  public PieceLikeResponse unlikePiece(CustomUserDetails userDetails, Long pieceId) {
+    pieceRepository
+        .findById(pieceId)
+        .orElseThrow(() -> new CustomException(PieceErrorCode.PIECE_NOT_FOUND));
+
+    Optional<PieceLike> pieceLike =
+        Optional.ofNullable(
+            pieceLikeRepository
+                .findByUser_IdAndPiece_Id(userDetails.getUser().getId(), pieceId)
+                .orElseThrow(() -> new CustomException(PieceLikeErrorCode.NOT_LIKED)));
+    pieceLike.ifPresent(pieceLikeRepository::delete);
+
+    return pieceLikeMapper.toPieceLikeResponse(pieceId, false);
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/user/entity/User.java
+++ b/src/main/java/com/likelion13/artium/domain/user/entity/User.java
@@ -3,6 +3,8 @@
  */
 package com.likelion13.artium.domain.user.entity;
 
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionUser;
+import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -20,7 +22,6 @@ import jakarta.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.likelion13.artium.domain.piece.entity.Piece;
-import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
 import lombok.AccessLevel;
@@ -68,6 +69,9 @@ public class User extends BaseTimeEntity {
   @Builder.Default
   private List<PieceLike> pieceLikes = new ArrayList<>();
 
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<ExhibitionUser> exhibitionUsers = new ArrayList<>();
+
   public static User fromOAuth(String email, String provider, String nickname) {
     return User.builder()
         .username(email)
@@ -76,5 +80,11 @@ public class User extends BaseTimeEntity {
         .provider(provider)
         .role(Role.USER)
         .build();
+  }
+
+  public void addPiece(Piece piece) {
+    if (piece == null) return;
+    if (this.pieces == null) this.pieces = new ArrayList<>();
+    this.pieces.add(piece);
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/user/entity/User.java
+++ b/src/main/java/com/likelion13/artium/domain/user/entity/User.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
 import lombok.AccessLevel;
@@ -60,7 +61,12 @@ public class User extends BaseTimeEntity {
   private Role role = Role.USER;
 
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+  @Builder.Default
   private List<Piece> pieces = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<PieceLike> pieceLikes = new ArrayList<>();
 
   public static User fromOAuth(String email, String provider, String nickname) {
     return User.builder()
@@ -70,11 +76,5 @@ public class User extends BaseTimeEntity {
         .provider(provider)
         .role(Role.USER)
         .build();
-  }
-
-  public void addPiece(Piece piece) {
-    if (piece == null) return;
-    if (this.pieces == null) this.pieces = new ArrayList<>();
-    this.pieces.add(piece);
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/user/entity/User.java
+++ b/src/main/java/com/likelion13/artium/domain/user/entity/User.java
@@ -3,8 +3,6 @@
  */
 package com.likelion13.artium.domain.user.entity;
 
-import com.likelion13.artium.domain.exhibition.mapping.ExhibitionUser;
-import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -21,7 +19,9 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionUser;
 import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
 import lombok.AccessLevel;

--- a/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
@@ -14,7 +14,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
   USERNAME_ALREADY_EXISTS("USER_4001", "이미 존재하는 사용자 아이디입니다.", HttpStatus.BAD_REQUEST),
-  USER_NOT_FOUND("USER_4002", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND);
+  USER_NOT_FOUND("USER_4002", "존재하지 않는 사용자입니다.", HttpStatus.NOT_FOUND),
+  UNAUTHORIZED("USER_4003", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/likelion13/artium/global/config/CorsConfig.java
+++ b/src/main/java/com/likelion13/artium/global/config/CorsConfig.java
@@ -4,6 +4,7 @@
 package com.likelion13.artium.global.config;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -26,7 +27,10 @@ public class CorsConfig {
     // 리스트에 작성한 HTTP 메소드 요청만 허용
     configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH"));
     // 리스트에 작성한 헤더들이 포함된 요청만 허용
-    configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Accept"));
+    configuration.setAllowedHeaders(
+        Arrays.asList("Authorization", "Content-Type", "X-Requested-With"));
+    // 응답에서 읽을 수 있는 헤더 지정
+    configuration.setExposedHeaders(List.of("Authorization"));
     // 쿠키나 인증 정보를 포함하는 요청 허용
     configuration.setAllowCredentials(true);
     // 모든 경로에 대해 위의 CORS 설정을 적용

--- a/src/main/java/com/likelion13/artium/global/config/S3Config.java
+++ b/src/main/java/com/likelion13/artium/global/config/S3Config.java
@@ -45,6 +45,9 @@ public class S3Config {
   @Value("${cloud.aws.s3.path.piece-detail}")
   private String pieceDetailPath;
 
+  @Value("${cloud.aws.s3.path.exhibition}")
+  private String exhibitionPath;
+
   @PostConstruct
   public void init() {
     this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);

--- a/src/main/java/com/likelion13/artium/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion13/artium/global/config/SecurityConfig.java
@@ -3,8 +3,6 @@
  */
 package com.likelion13.artium.global.config;
 
-import jakarta.servlet.http.HttpServletResponse;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -41,12 +39,6 @@ public class SecurityConfig {
         .csrf(AbstractHttpConfigurer::disable)
         // CORS 설정 활성화
         .cors(cors -> cors.configurationSource(corsConfig.corsConfigurationSource()))
-        .exceptionHandling(
-            exception ->
-                exception.authenticationEntryPoint(
-                    (request, response, authException) -> {
-                      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
-                    }))
         // 세션을 생성하지 않음 (JWT 사용으로 인한 Stateless 설정
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/likelion13/artium/global/jwt/JwtProperties.java
+++ b/src/main/java/com/likelion13/artium/global/jwt/JwtProperties.java
@@ -12,9 +12,8 @@ import lombok.Setter;
 /**
  * JWT 관련 설정 속성
  *
- * <p>application.properties 또는 application.yml에서 jwt 접두사를 가진 속성들을 관리합니다.
+ * <p>application 또는 application.yml에서 jwt 접두사를 가진 속성들을 관리합니다.
  *
- * @author YFIVE
  * @since 1.0.0
  */
 @Component

--- a/src/main/java/com/likelion13/artium/global/jwt/JwtProvider.java
+++ b/src/main/java/com/likelion13/artium/global/jwt/JwtProvider.java
@@ -3,125 +3,349 @@
  */
 package com.likelion13.artium.global.jwt;
 
-import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+import javax.crypto.SecretKey;
+
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
 
-import com.likelion13.artium.domain.auth.exception.AuthErrorCode;
+import com.likelion13.artium.domain.auth.dto.response.TokenResponse;
+import com.likelion13.artium.domain.user.exception.UserErrorCode;
 import com.likelion13.artium.global.exception.CustomException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * JWT 토큰 생성 및 검증을 담당하는 클래스
+ *
+ * <p>이 클래스는 JWT 토큰의 생성, 검증, 파싱 등의 기능을 제공합니다. Access Token과 Refresh Token을 모두 지원하며, Redis를 통한 토큰 관리
+ * 기능을 포함합니다.
+ *
+ * @since 1.0.0
+ */
 @Slf4j
 @Component
 public class JwtProvider {
 
-  private final Key key;
-  private final long accessTokenExpireTime;
-  private final long refreshTokenExpireTime;
+  /** JWT 설정 속성 */
+  private final JwtProperties jwtProperties;
 
-  public JwtProvider(
-      @Value("${spring.jwt.secret}") String secretKey,
-      @Value("${spring.jwt.access-token-expire-time}") long accessTokenExpireTime,
-      @Value("${spring.jwt.refresh-token-expire-time}") long refreshTokenExpireTime) {
-    byte[] keyBytes = java.util.Base64.getDecoder().decode(secretKey);
-    this.key = Keys.hmacShaKeyFor(keyBytes);
-    this.accessTokenExpireTime = accessTokenExpireTime;
-    this.refreshTokenExpireTime = refreshTokenExpireTime;
+  /** JWT 서명 키 */
+  private SecretKey key;
+
+  /** 토큰 저장소 */
+  private final TokenRepository tokenRepository;
+
+  /** Access Token 타입 상수 */
+  public static final String TOKEN_TYPE_ACCESS = "access";
+
+  /** Refresh Token 타입 상수 */
+  public static final String TOKEN_TYPE_REFRESH = "refresh";
+
+  /**
+   * 생성자
+   *
+   * @param jwtProperties JWT 설정 속성
+   * @param tokenRepository 토큰 저장소
+   */
+  public JwtProvider(JwtProperties jwtProperties, TokenRepository tokenRepository) {
+    this.jwtProperties = jwtProperties;
+    this.tokenRepository = tokenRepository;
   }
 
-  public String createAccessToken(String username, String role, String provider) {
-    Date now = new Date();
-    Claims claims = Jwts.claims().setSubject(username).setId(username); // tokenId 대용
-    claims.put("roles", role); // ex: ["ROLE_USER"]
-    claims.put("provider", provider); // ex: "google"
-
-    return Jwts.builder()
-        .setClaims(claims)
-        .setIssuedAt(now)
-        .setExpiration(new Date(now.getTime() + accessTokenExpireTime))
-        .signWith(key, SignatureAlgorithm.HS256)
-        .compact();
+  /**
+   * 초기화 메서드
+   *
+   * <p>시크릿 키를 Base64로 디코딩하여 JWT 서명 키를 생성합니다. 디코딩에 실패할 경우 일반 텍스트로 처리합니다.
+   */
+  @PostConstruct
+  public void init() {
+    // Base64 디코딩 시도
+    try {
+      byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecret());
+      this.key = Keys.hmacShaKeyFor(keyBytes);
+    } catch (Exception e) {
+      // 디코딩 실패 시 일반 텍스트로 처리
+      log.warn("Base64 디코딩 실패, 일반 텍스트로 처리합니다: {}", e.getMessage());
+      this.key = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes());
+    }
+    log.info("JWT key initialized");
   }
 
-  public long getExpiration(String accessToken) {
-    Claims claims = parseClaims(accessToken);
+  /**
+   * Access Token과 Refresh Token을 모두 생성
+   *
+   * <p>인증 정보를 기반으로 Access Token과 Refresh Token을 생성하고, Refresh Token은 Redis에 저장합니다.
+   *
+   * @param authentication 인증 정보
+   * @return 토큰 응답 객체
+   */
+  public TokenResponse createTokens(Authentication authentication) {
+    String username = authentication.getName();
 
-    Date expiration = claims.getExpiration();
+    // Access Token 생성
+    String accessToken = createToken(authentication, TOKEN_TYPE_ACCESS);
+
+    // Refresh Token 생성
+    String refreshToken = createToken(authentication, TOKEN_TYPE_REFRESH);
+
+    // Refresh Token을 Redis에 저장
+    tokenRepository.saveRefreshToken(username, refreshToken);
+
+    // TokenResponse 객체 생성하여 반환
+    return TokenResponse.builder()
+        .accessToken(accessToken)
+        .refreshToken(refreshToken)
+        .username(username)
+        .build();
+  }
+
+  /**
+   * 지정된 타입의 JWT 토큰 생성
+   *
+   * <p>인증 정보와 토큰 타입을 기반으로 JWT 토큰을 생성합니다. 토큰 타입에 따라 유효 기간이 다르게 설정됩니다.
+   *
+   * @param authentication 인증 정보
+   * @param tokenType 토큰 타입 (access 또는 refresh)
+   * @return 생성된 JWT 토큰
+   */
+  public String createToken(Authentication authentication, String tokenType) {
+    String authorities =
+        authentication.getAuthorities().stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(Collectors.joining(","));
+
+    OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+    Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
+
+    if (kakaoAccount == null || !kakaoAccount.containsKey("email")) {
+      throw new CustomException(UserErrorCode.UNAUTHORIZED);
+    }
+
+    String email = (String) kakaoAccount.get("email");
+
     long now = System.currentTimeMillis();
-    return expiration.getTime() - now;
-  }
+    Date validity;
 
-  private Key getSigningKey() {
-    return key;
-  }
+    // 토큰 타입에 따라 유효기간 설정
+    if (TOKEN_TYPE_REFRESH.equals(tokenType)) {
+      validity = new Date(now + jwtProperties.getRefreshTokenValidityInSeconds() * 1000);
+    } else {
+      validity = new Date(now + jwtProperties.getAccessTokenValidityInSeconds() * 1000);
+    }
 
-  public String createRefreshToken(String username, String tokenId) {
-    Date now = new Date();
     return Jwts.builder()
-        .setSubject(username)
-        .setId(tokenId)
-        .setIssuedAt(now)
-        .setExpiration(new Date(now.getTime() + refreshTokenExpireTime))
-        .signWith(key, SignatureAlgorithm.HS256)
+        .setSubject(email)
+        .claim("auth", authorities)
+        .claim("type", tokenType)
+        .setIssuedAt(new Date(now))
+        .setExpiration(validity)
+        .signWith(key)
         .compact();
   }
 
-  public void addJwtToCookie(HttpServletResponse response, String token, String name, long maxAge) {
-    Cookie cookie = new Cookie(name, token);
-    cookie.setHttpOnly(true);
-    // cookie.setSecure(true); // HTTPS 환경에서만 전송되게
-    cookie.setPath("/");
-    cookie.setMaxAge((int) maxAge / 1000); // 단위: 초
-    response.addCookie(cookie);
+  /**
+   * Access Token 생성 (하위 호환성 유지)
+   *
+   * @param authentication 인증 정보
+   * @return 생성된 Access Token
+   */
+  public String createToken(Authentication authentication) {
+    return createToken(authentication, TOKEN_TYPE_ACCESS);
   }
 
+  /**
+   * 토큰에서 인증 정보 추출
+   *
+   * <p>JWT 토큰을 파싱하여 사용자 인증 정보를 추출합니다.
+   *
+   * @param token JWT 토큰
+   * @return 인증 정보
+   */
+  public Authentication getAuthentication(String token) {
+    Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+
+    Collection<? extends GrantedAuthority> authorities =
+        Arrays.stream(claims.get("auth").toString().split(","))
+            .map(SimpleGrantedAuthority::new)
+            .collect(Collectors.toList());
+
+    Map<String, Object> attributes = Map.of("email", claims.getSubject());
+    OAuth2User principal = new DefaultOAuth2User(authorities, attributes, "email");
+    return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+  }
+
+  /**
+   * 토큰에서 사용자 이름 추출
+   *
+   * @param token JWT 토큰
+   * @return 사용자 이름
+   */
+  public String getUsernameFromToken(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody()
+        .getSubject();
+  }
+
+  /**
+   * 토큰에서 토큰 타입 추출
+   *
+   * @param token JWT 토큰
+   * @return 토큰 타입 (access 또는 refresh)
+   */
+  public String getTokenType(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(key)
+        .build()
+        .parseClaimsJws(token)
+        .getBody()
+        .get("type", String.class);
+  }
+
+  /**
+   * 토큰 유효성 검사
+   *
+   * <p>JWT 토큰의 유효성을 검사합니다. 블랙리스트에 등록된 토큰은 유효하지 않습니다.
+   *
+   * @param token JWT 토큰
+   * @return 유효성 여부
+   */
   public boolean validateToken(String token) {
     try {
-      parseClaims(token);
+      // 블랙리스트 확인
+      if (tokenRepository.isBlacklisted(token)) {
+        log.info("블랙리스트에 등록된 토큰입니다.");
+        return false;
+      }
+
+      Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
       return true;
+    } catch (SignatureException | MalformedJwtException e) {
+      log.info("잘못된 JWT 서명입니다.");
     } catch (ExpiredJwtException e) {
-      throw new CustomException(AuthErrorCode.JWT_TOKEN_EXPIRED);
+      log.info("만료된 JWT 토큰입니다.");
     } catch (UnsupportedJwtException e) {
-      throw new CustomException(AuthErrorCode.UNSUPPORTED_TOKEN);
-    } catch (MalformedJwtException e) {
-      throw new CustomException(AuthErrorCode.MALFORMED_JWT_TOKEN);
-    } catch (io.jsonwebtoken.SignatureException e) {
-      throw new CustomException(AuthErrorCode.INVALID_SIGNATURE);
+      log.info("지원되지 않는 JWT 토큰입니다.");
     } catch (IllegalArgumentException e) {
-      throw new CustomException(AuthErrorCode.ILLEGAL_ARGUMENT);
+      log.info("JWT 토큰이 잘못되었습니다.");
+    }
+    return false;
+  }
+
+  /**
+   * 특정 토큰 타입 검증
+   *
+   * <p>토큰의 타입이 기대하는 타입과 일치하는지 검증합니다.
+   *
+   * @param token JWT 토큰
+   * @param expectedType 기대하는 토큰 타입
+   * @return 일치 여부
+   */
+  public boolean validateTokenType(String token, String expectedType) {
+    try {
+      String tokenType = getTokenType(token);
+      return expectedType.equals(tokenType);
+    } catch (Exception e) {
+      log.info("토큰 타입 검증 실패: {}", e.getMessage());
+      return false;
     }
   }
 
-  public String extractSocialId(String token) {
-    return parseClaims(token).getSubject();
+  /**
+   * 토큰 만료 시간 추출
+   *
+   * <p>토큰의 남은 유효 시간을 초 단위로 반환합니다.
+   *
+   * @param token JWT 토큰
+   * @return 남은 유효 시간 (초)
+   */
+  public long getExpirationTime(String token) {
+    try {
+      Date expiration =
+          Jwts.parserBuilder()
+              .setSigningKey(key)
+              .build()
+              .parseClaimsJws(token)
+              .getBody()
+              .getExpiration();
+      return (expiration.getTime() - System.currentTimeMillis()) / 1000;
+    } catch (Exception e) {
+      return 0;
+    }
   }
 
-  public String extractTokenId(String token) {
-    return parseClaims(token).getId();
+  /**
+   * 토큰 블랙리스트에 추가
+   *
+   * <p>로그아웃 시 토큰을 블랙리스트에 추가하여 더 이상 사용할 수 없게 합니다.
+   *
+   * @param token JWT 토큰
+   */
+  public void blacklistToken(String token) {
+    long expiration = getExpirationTime(token);
+    if (expiration > 0) {
+      tokenRepository.addToBlacklist(token, expiration);
+    }
   }
 
-  public String getUsernameFromToken(String token) {
-    return parseClaims(token).getSubject();
+  /**
+   * Refresh Token 검증
+   *
+   * <p>사용자의 Refresh Token이 Redis에 저장된 토큰과 일치하는지 검증합니다.
+   *
+   * @param username 사용자 이름
+   * @param refreshToken Refresh Token
+   * @return 일치 여부
+   */
+  public boolean validateRefreshToken(String username, String refreshToken) {
+    String storedToken = tokenRepository.findRefreshToken(username);
+    return storedToken != null && storedToken.equals(refreshToken);
   }
 
-  private Claims parseClaims(String token) {
-    return Jwts.parserBuilder()
-        .setSigningKey(getSigningKey())
-        .build()
-        .parseClaimsJws(token)
-        .getBody();
+  /**
+   * JWT 토큰을 HTTP 응답의 쿠키에 추가합니다.
+   *
+   * <p>이 메서드는 주어진 JWT 토큰을 HttpOnly 및 Secure 속성이 설정된 쿠키로 만들어 응답에 추가합니다. 이 쿠키는 클라이언트에서 JavaScript로
+   * 접근할 수 없으며, HTTPS 환경에서만 전송됩니다.
+   *
+   * @param response 응답 객체 (HttpServletResponse)
+   * @param token 쿠키에 저장할 JWT 토큰 값
+   * @param name 쿠키 이름 (예: "accessToken", "refreshToken")
+   * @param maxAge 쿠키의 유효 시간 (밀리초 단위)
+   */
+  public void addJwtToCookie(HttpServletResponse response, String token, String name, long maxAge) {
+    Cookie cookie = new Cookie(name, token);
+    cookie.setHttpOnly(true);
+    // cookie.setSecure(true);
+    cookie.setPath("/");
+    cookie.setMaxAge((int) (maxAge / 1000));
+    response.addCookie(cookie);
+
+    log.info("JWT 쿠키가 설정되었습니다 - 이름: {}, 만료: {}초", name, cookie.getMaxAge());
   }
 }

--- a/src/main/java/com/likelion13/artium/global/jwt/TokenRepository.java
+++ b/src/main/java/com/likelion13/artium/global/jwt/TokenRepository.java
@@ -17,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
  * <p>Redis를 사용하여 Refresh Token 및 블랙리스트 토큰을 관리합니다. Refresh Token은 사용자별로 저장되며, 블랙리스트는 로그아웃된 토큰을
  * 관리합니다.
  *
- * @author YFIVE
  * @since 1.0.0
  */
 @Slf4j

--- a/src/main/java/com/likelion13/artium/global/page/exception/PageErrorStatus.java
+++ b/src/main/java/com/likelion13/artium/global/page/exception/PageErrorStatus.java
@@ -1,0 +1,23 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.global.page.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.likelion13.artium.global.exception.model.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PageErrorStatus implements BaseErrorCode {
+  PAGE_NOT_FOUND("PAGE001", "페이지가 존재하지 않습니다.", HttpStatus.NOT_FOUND),
+  PAGE_SIZE_ERROR("PAGE002", "페이지 크기 오류가 발생했습니다.", HttpStatus.BAD_REQUEST),
+  PAGING_ERROR("PAGE003", "페이징 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/likelion13/artium/global/page/mapper/PageMapper.java
+++ b/src/main/java/com/likelion13/artium/global/page/mapper/PageMapper.java
@@ -1,0 +1,30 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.global.page.mapper;
+
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
+import com.likelion13.artium.global.page.response.PageResponse;
+
+@Component
+public class PageMapper {
+
+  private <T> PageResponse<T> toPageResponse(Page<T> page) {
+    return PageResponse.<T>builder()
+        .content(page.getContent())
+        .totalElements(page.getTotalElements())
+        .totalPages(page.getTotalPages())
+        .pageNum(page.getNumber())
+        .pageSize(page.getSize())
+        .last(page.isLast())
+        .first(page.isFirst())
+        .build();
+  }
+
+  public PageResponse<ExhibitionResponse> toExhibitionPageResponse(Page<ExhibitionResponse> page) {
+    return toPageResponse(page);
+  }
+}

--- a/src/main/java/com/likelion13/artium/global/page/response/PageResponse.java
+++ b/src/main/java/com/likelion13/artium/global/page/response/PageResponse.java
@@ -1,0 +1,37 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.global.page.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "PageResponse DTO", description = "응답 객체들에 대한 리스트를 페이지로 응답 반환")
+public class PageResponse<T> {
+
+  @Schema(description = "데이터 리스트")
+  private List<T> content;
+
+  @Schema(description = "전체 데이터의 개수", example = "200")
+  private Long totalElements;
+
+  @Schema(description = "전체 페이지 개수", example = "50")
+  private Integer totalPages;
+
+  @Schema(description = "페이지 번호", example = "0")
+  private Integer pageNum;
+
+  @Schema(description = "페이지 크기", example = "4")
+  private Integer pageSize;
+
+  @Schema(description = "첫 번째 데이터 여부", example = "true")
+  private Boolean first;
+
+  @Schema(description = "마지막 데이터 여부", example = "false")
+  private Boolean last;
+}

--- a/src/main/java/com/likelion13/artium/global/s3/entity/PathName.java
+++ b/src/main/java/com/likelion13/artium/global/s3/entity/PathName.java
@@ -11,5 +11,7 @@ public enum PathName {
   @Schema(description = "작품사진")
   PIECE,
   @Schema(description = "작품 디테일컷")
-  PIECE_DETAIL
+  PIECE_DETAIL,
+  @Schema(description = "전시 썸네일사진")
+  EXHIBITION
 }

--- a/src/main/java/com/likelion13/artium/global/s3/service/S3ServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/global/s3/service/S3ServiceImpl.java
@@ -132,6 +132,7 @@ public class S3ServiceImpl implements S3Service {
       case PROFILE_IMAGE -> s3Config.getProfileImagePath();
       case PIECE -> s3Config.getPiecePath();
       case PIECE_DETAIL -> s3Config.getPieceDetailPath();
+      case EXHIBITION -> s3Config.getExhibitionPath();
     };
   }
 }

--- a/src/main/java/com/likelion13/artium/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/likelion13/artium/global/security/JwtAuthenticationFilter.java
@@ -42,7 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
       String token = resolveToken(request);
 
       if (token != null && jwtProvider.validateToken(token)) {
-        String socialId = jwtProvider.extractSocialId(token);
+        String socialId = jwtProvider.getUsernameFromToken(token);
         UserDetails userDetails = userDetailsService.loadUserByUsername(socialId);
 
         UsernamePasswordAuthenticationToken authentication =


### PR DESCRIPTION
## ✨ 새로운 기능
- 어떤 기능을 추가했나요? : 작품 좋아요 관련 기능 추가
- 사용자에게 어떤 이점을 주나요? : 사용자가 여러 작품들을 좋아요 할 수 있게하여, 좋아하는 작품을 쉽게 모아볼 수 있고, 좋아요 기반 추천을 할 수 있게 함

## 🛠 개발 상세
- 구현 방식 요약 : PieceLike 도메인형 계층형 아키텍처 형식으로 기능 개발

## 🧪 테스트 방법
- Swagger의 Piece Like 부분에서 테스트

## 🧩 추가 수정사항
- 작품 관련 기능 리팩토링(Piece, PieceDetail, User)

## 🔗 관련 문서 / 이슈
- issue: #7 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Like/unlike a piece via new endpoints; piece responses include your like status.
  - Piece creation accepts a main image plus optional detail images and returns a summary payload.
  - New exhibition APIs: create exhibition (image + data) and paginated user exhibition listing.

- **Changes**
  - Enforces max 5 detail images, validates kept detail images belong to the piece, and cleans up removed images and main-image updates.
  - Deletion and several actions require authenticated user context; login now issues tokens via cookies (access/refresh).

- **Documentation**
  - API docs mark piece endpoints as login-required and refine field descriptions; paginated response DTOs added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->