### PR TITLE
:sparkles:Feat: 감상평 관련 기능 작업

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - artium-network
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping", "-a", "${REDIS_PASS}"]
+      test: ["CMD", "redis-cli", "-a", "${REDIS_PASS}", "ping"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    build: .
+    image: artium-app:latest
     container_name: artium-app
     ports:
       - "8080:8080"
@@ -11,19 +11,21 @@ services:
       SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/${DB_NAME}
       SPRING_DATASOURCE_USERNAME: ${DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASS}
-    command: ["java", "-Dspring.profiles.active=${PROFILE:-dev}", "-jar", "app.jar"]
+    command: ["java", "-jar", "app.jar"]
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     networks:
       - artium-network
-    restart: on-failure
+    restart: unless-stopped
 
   mysql:
     image: mysql:8.0
     container_name: artium-mysql
-    ports:
-      - "3306:3306"
+    expose:
+      - "3306"
     environment:
       MYSQL_DATABASE: ${DB_NAME}
       MYSQL_USER: ${DB_USER}
@@ -33,18 +35,45 @@ services:
       - mysql-data:/var/lib/mysql
     networks:
       - artium-network
-    restart: always
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   redis:
     image: redis:7.2-alpine
     container_name: artium-redis
-    ports:
-      - "6379:6379"
+    expose:
+      - "6379"
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASS}
+    command: ["redis-server", "--requirepass", "${REDIS_PASS}"]
     volumes:
       - redis-data:/data
     networks:
       - artium-network
-    restart: always
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping", "-a", "${REDIS_PASS}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  qdrant:
+    image: qdrant/qdrant:v1.12.3
+    container_name: artium-qdrant
+    ports:
+      - "6333:6333"
+      - "6334:6334"
+    volumes:
+      - qdrant-data:/qdrant/storage
+    networks:
+      - artium-network
+    restart: unless-stopped
 
 networks:
   artium-network:
@@ -53,3 +82,4 @@ networks:
 volumes:
   mysql-data:
   redis-data:
+  qdrant-data:

--- a/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
@@ -52,7 +52,7 @@ public class Exhibition extends BaseTimeEntity {
   @Column(name = "title")
   private String title;
 
-  @Column(name = "description")
+  @Column(name = "description", columnDefinition = "TEXT")
   private String description;
 
   @Column(name = "start_date")
@@ -64,7 +64,7 @@ public class Exhibition extends BaseTimeEntity {
   @Column(name = "address")
   private String address;
 
-  @Column(name = "offline_description")
+  @Column(name = "offline_description", columnDefinition = "TEXT")
   private String offlineDescription;
 
   @Column(name = "account_number")

--- a/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
@@ -23,6 +23,7 @@ import jakarta.persistence.Table;
 
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionLike;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionParticipant;
+import com.likelion13.artium.domain.review.entity.Review;
 import com.likelion13.artium.domain.user.entity.User;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
@@ -92,6 +93,10 @@ public class Exhibition extends BaseTimeEntity {
   @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<ExhibitionLike> exhibitionLikes = new ArrayList<>();
+
+  @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<Review> reviews = new ArrayList<>();
 
   public void update(Exhibition exhibition) {
     this.thumbnailImageUrl = exhibition.getThumbnailImageUrl();

--- a/src/main/java/com/likelion13/artium/domain/exhibition/service/ExhibitionServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/service/ExhibitionServiceImpl.java
@@ -93,6 +93,7 @@ public class ExhibitionServiceImpl implements ExhibitionService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public ExhibitionDetailResponse getExhibition(Long id) {
 
     Exhibition exhibition =
@@ -104,6 +105,7 @@ public class ExhibitionServiceImpl implements ExhibitionService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public Integer getExhibitionDraftCount() {
 
     return exhibitionRepository
@@ -112,6 +114,7 @@ public class ExhibitionServiceImpl implements ExhibitionService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public PageResponse<ExhibitionResponse> getExhibitionPageByType(
       SortBy sortBy, Pageable pageable) {
     Page<ExhibitionResponse> page;
@@ -142,6 +145,7 @@ public class ExhibitionServiceImpl implements ExhibitionService {
   }
 
   @Override
+  @Transactional(readOnly = true)
   public PageResponse<ExhibitionResponse> getExhibitionPageByUser(
       Boolean fillAll, Pageable pageable) {
     User user = userService.getCurrentUser();

--- a/src/main/java/com/likelion13/artium/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/likelion13/artium/domain/review/controller/ReviewController.java
@@ -3,8 +3,6 @@
  */
 package com.likelion13.artium.domain.review.controller;
 
-import java.util.List;
-
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -15,9 +13,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
 import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
+import com.likelion13.artium.global.page.response.PageResponse;
 import com.likelion13.artium.global.response.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -29,7 +29,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 public interface ReviewController {
 
   @PostMapping
-  @Operation(summary = "감상평 작성", description = "좋아요 할 사용자의 식별자를 요청 받아 좋아요를 등록합니다.")
+  @Operation(summary = "감상평 작성", description = "전시 식별자와 감상평 내용을 요청 받아 감상평을 등록합니다.")
   ResponseEntity<BaseResponse<ReviewResponse>> createReview(
       @Parameter(description = "감상평을 작성할 전시 식별자", example = "1")
           @PathVariable(name = "exhibition-id")
@@ -37,11 +37,13 @@ public interface ReviewController {
       @Parameter(description = "감상평 작성 요청 정보") @Valid @RequestBody ReviewRequest request);
 
   @GetMapping
-  @Operation(summary = "감상평 조회", description = "전시 식별자에 대한 감상평 리스트를 조회합니다.")
-  ResponseEntity<BaseResponse<List<ReviewResponse>>> getReviewByExhibitionId(
+  @Operation(summary = "감상평 리스트 조회", description = "전시 식별자에 대한 최신순 감상평 리스트를 페이지로 조회합니다.")
+  ResponseEntity<BaseResponse<PageResponse<ReviewResponse>>> getReviewByExhibitionId(
       @Parameter(description = "감상평을 조회할 전시 식별자", example = "1")
           @PathVariable(name = "exhibition-id")
-          Long exhibitionId);
+          Long exhibitionId,
+      @Parameter(description = "페이지 번호", example = "1") @RequestParam Integer pageNum,
+      @Parameter(description = "페이지 크기", example = "3") @RequestParam Integer pageSize);
 
   @PutMapping("/{review-id}")
   @Operation(summary = "감상평 수정", description = "감상평 식별자를 요청 받아 사용자가 작성했던 감상평을 수정합니다.")

--- a/src/main/java/com/likelion13/artium/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/likelion13/artium/domain/review/controller/ReviewController.java
@@ -1,0 +1,64 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
+import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
+import com.likelion13.artium.global.response.BaseResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "감상평", description = "감상평 관련 API")
+@RequestMapping("/api/exhibitions/{exhibition-id}/reviews")
+public interface ReviewController {
+
+  @PostMapping
+  @Operation(summary = "감상평 작성", description = "좋아요 할 사용자의 식별자를 요청 받아 좋아요를 등록합니다.")
+  ResponseEntity<BaseResponse<ReviewResponse>> createReview(
+      @Parameter(description = "감상평을 작성할 전시 식별자", example = "1")
+          @PathVariable(name = "exhibition-id")
+          Long exhibitionId,
+      @Parameter(description = "감상평 작성 요청 정보") @Valid @RequestBody ReviewRequest request);
+
+  @GetMapping
+  @Operation(summary = "감상평 조회", description = "전시 식별자에 대한 감상평 리스트를 조회합니다.")
+  ResponseEntity<BaseResponse<List<ReviewResponse>>> getReviewByExhibitionId(
+      @Parameter(description = "감상평을 조회할 전시 식별자", example = "1")
+          @PathVariable(name = "exhibition-id")
+          Long exhibitionId);
+
+  @PutMapping("/{review-id}")
+  @Operation(summary = "감상평 수정", description = "감상평 식별자를 요청 받아 사용자가 작성했던 감상평을 수정합니다.")
+  ResponseEntity<BaseResponse<ReviewResponse>> updateReview(
+      @Parameter(description = "감상평을 수정할 전시 식별자", example = "1")
+          @PathVariable(name = "exhibition-id")
+          Long exhibitionId,
+      @Parameter(description = "수정할 감상평 식별자", example = "1") @PathVariable(name = "review-id")
+          Long reviewId,
+      @Parameter(description = "감상평 수정 요청 정보") @Valid @RequestBody ReviewRequest request);
+
+  @DeleteMapping("/{review-id}")
+  @Operation(summary = "감상평 삭제", description = "감상평 식별자를 요청 받아 사용자가 작성했던 감상평을 삭제합니다.")
+  ResponseEntity<BaseResponse<String>> deleteReview(
+      @Parameter(description = "감상평을 삭제할 전시 식별자", example = "1")
+          @PathVariable(name = "exhibition-id")
+          Long exhibitionId,
+      @Parameter(description = "삭제할 감상평 식별자", example = "1") @PathVariable(name = "review-id")
+          Long reviewId);
+}

--- a/src/main/java/com/likelion13/artium/domain/review/controller/ReviewControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/review/controller/ReviewControllerImpl.java
@@ -3,18 +3,22 @@
  */
 package com.likelion13.artium.domain.review.controller;
 
-import java.util.List;
-
 import jakarta.validation.Valid;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
 import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
 import com.likelion13.artium.domain.review.service.ReviewService;
+import com.likelion13.artium.global.exception.CustomException;
+import com.likelion13.artium.global.page.exception.PageErrorStatus;
+import com.likelion13.artium.global.page.response.PageResponse;
 import com.likelion13.artium.global.response.BaseResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -36,11 +40,22 @@ public class ReviewControllerImpl implements ReviewController {
   }
 
   @Override
-  public ResponseEntity<BaseResponse<List<ReviewResponse>>> getReviewByExhibitionId(
-      @PathVariable(name = "exhibition-id") Long exhibitionId) {
+  public ResponseEntity<BaseResponse<PageResponse<ReviewResponse>>> getReviewByExhibitionId(
+      @PathVariable(name = "exhibition-id") Long exhibitionId,
+      @RequestParam Integer pageNum,
+      @RequestParam Integer pageSize) {
+
+    if (pageNum < 1) {
+      throw new CustomException(PageErrorStatus.PAGE_NOT_FOUND);
+    }
+    if (pageSize < 1) {
+      throw new CustomException(PageErrorStatus.PAGE_SIZE_ERROR);
+    }
+
+    Pageable pageable = PageRequest.of(pageNum - 1, pageSize);
 
     return ResponseEntity.status(200)
-        .body(BaseResponse.success(reviewService.getReviewByExhibitionId(exhibitionId)));
+        .body(BaseResponse.success(reviewService.getReviewByExhibitionId(exhibitionId, pageable)));
   }
 
   @Override

--- a/src/main/java/com/likelion13/artium/domain/review/controller/ReviewControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/review/controller/ReviewControllerImpl.java
@@ -1,0 +1,65 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
+import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
+import com.likelion13.artium.domain.review.service.ReviewService;
+import com.likelion13.artium.global.response.BaseResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewControllerImpl implements ReviewController {
+
+  private final ReviewService reviewService;
+
+  @Override
+  public ResponseEntity<BaseResponse<ReviewResponse>> createReview(
+      @PathVariable(name = "exhibition-id") Long exhibitionId,
+      @Valid @RequestBody ReviewRequest request) {
+
+    ReviewResponse reviewResponse = reviewService.createReview(exhibitionId, request);
+
+    return ResponseEntity.status(201).body(BaseResponse.success(reviewResponse));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<List<ReviewResponse>>> getReviewByExhibitionId(
+      @PathVariable(name = "exhibition-id") Long exhibitionId) {
+
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(reviewService.getReviewByExhibitionId(exhibitionId)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<ReviewResponse>> updateReview(
+      @PathVariable(name = "exhibition-id") Long exhibitionId,
+      @PathVariable(name = "review-id") Long reviewId,
+      @Valid @RequestBody ReviewRequest request) {
+
+    ReviewResponse reviewResponse = reviewService.updateReview(exhibitionId, reviewId, request);
+
+    return ResponseEntity.status(200).body(BaseResponse.success(reviewResponse));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> deleteReview(
+      @PathVariable(name = "exhibition-id") Long exhibitionId,
+      @PathVariable(name = "review-id") Long reviewId) {
+
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(reviewService.deleteReview(exhibitionId, reviewId)));
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/review/dto/request/ReviewRequest.java
+++ b/src/main/java/com/likelion13/artium/domain/review/dto/request/ReviewRequest.java
@@ -1,0 +1,24 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(title = "ReviewRequest DTO", description = "감상평 등록을 위한 데이터 DTO")
+public class ReviewRequest {
+
+  @NotBlank(message = "감상평 내용 항목은 필수입니다.")
+  @Schema(description = "감상평 내용", example = "재미있었습니다.")
+  private String content;
+}

--- a/src/main/java/com/likelion13/artium/domain/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/review/dto/response/ReviewResponse.java
@@ -1,0 +1,28 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "ReviewResponse DTO", description = "감상평 정보 응답 반환")
+public class ReviewResponse {
+
+  @Schema(description = "감상평 식별자", example = "1")
+  private Long reviewId;
+
+  @Schema(description = "감상평 내용", example = "재미있었습니다.")
+  private String content;
+
+  @Schema(description = "작성 시간", example = "")
+  private LocalDateTime createdAt;
+
+  @Schema(description = "본인 작성 여부", example = "false")
+  private Boolean isAuthor;
+}

--- a/src/main/java/com/likelion13/artium/domain/review/entity/Review.java
+++ b/src/main/java/com/likelion13/artium/domain/review/entity/Review.java
@@ -35,7 +35,7 @@ public class Review extends BaseTimeEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(name = "content", nullable = false)
+  @Column(name = "content", nullable = false, columnDefinition = "TEXT")
   private String content;
 
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/likelion13/artium/domain/review/entity/Review.java
+++ b/src/main/java/com/likelion13/artium/domain/review/entity/Review.java
@@ -1,0 +1,52 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.global.common.BaseTimeEntity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "review")
+public class Review extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "content", nullable = false)
+  private String content;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "exhibition_id", nullable = false)
+  private Exhibition exhibition;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  public void update(String content) {
+    this.content = content;
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/review/exception/ReviewErrorCode.java
@@ -1,0 +1,23 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.likelion13.artium.global.exception.model.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ReviewErrorCode implements BaseErrorCode {
+  REVIEW_NOT_FOUND("REVIEW_4003", "감상평을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  REVIEW_ACCESS_DENIED("REVIEW_4004", "해당 감상평에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN),
+  REVIEW_API_ERROR("REVIEW_5001", "감상평 API 처리 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
+}

--- a/src/main/java/com/likelion13/artium/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/review/mapper/ReviewMapper.java
@@ -1,0 +1,28 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.mapper;
+
+import org.springframework.stereotype.Component;
+
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
+import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
+import com.likelion13.artium.domain.review.entity.Review;
+import com.likelion13.artium.domain.user.entity.User;
+
+@Component
+public class ReviewMapper {
+
+  public Review toReview(ReviewRequest request, Exhibition exhibition, User user) {
+    return Review.builder().content(request.getContent()).exhibition(exhibition).user(user).build();
+  }
+
+  public ReviewResponse toReviewResponse(Review review) {
+    return ReviewResponse.builder()
+        .reviewId(review.getId())
+        .content(review.getContent())
+        .createdAt(review.getCreatedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/review/mapper/ReviewMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/review/mapper/ReviewMapper.java
@@ -18,11 +18,12 @@ public class ReviewMapper {
     return Review.builder().content(request.getContent()).exhibition(exhibition).user(user).build();
   }
 
-  public ReviewResponse toReviewResponse(Review review) {
+  public ReviewResponse toReviewResponse(Review review, Boolean isAuthor) {
     return ReviewResponse.builder()
         .reviewId(review.getId())
         .content(review.getContent())
         .createdAt(review.getCreatedAt())
+        .isAuthor(isAuthor)
         .build();
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/review/repository/ReviewRepository.java
@@ -3,13 +3,13 @@
  */
 package com.likelion13.artium.domain.review.repository;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.likelion13.artium.domain.review.entity.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-  List<Review> findByExhibitionId(Long exhibitionId);
+  Page<Review> findByExhibitionIdOrderByCreatedAtDesc(Long exhibitionId, Pageable pageable);
 }

--- a/src/main/java/com/likelion13/artium/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,15 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.likelion13.artium.domain.review.entity.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+  List<Review> findByExhibitionId(Long exhibitionId);
+}

--- a/src/main/java/com/likelion13/artium/domain/review/service/ReviewService.java
+++ b/src/main/java/com/likelion13/artium/domain/review/service/ReviewService.java
@@ -1,0 +1,60 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.service;
+
+import java.util.List;
+
+import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
+import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
+
+/**
+ * 리뷰 관련 주요 기능을 제공하는 서비스 인터페이스입니다.
+ *
+ * <p>주요 기능:
+ *
+ * <ul>
+ *   <li>리뷰 생성
+ *   <li>특정 전시회 리뷰 조회
+ *   <li>리뷰 수정
+ *   <li>리뷰 삭제
+ * </ul>
+ */
+public interface ReviewService {
+
+  /**
+   * 특정 전시회에 대한 리뷰를 생성합니다.
+   *
+   * @param exhibitionId 리뷰를 작성할 전시회 ID
+   * @param request 리뷰 작성 요청 데이터 (내용, 평점 등)
+   * @return 생성된 리뷰의 응답 DTO
+   */
+  ReviewResponse createReview(Long exhibitionId, ReviewRequest request);
+
+  /**
+   * 특정 전시회에 등록된 모든 리뷰를 조회합니다.
+   *
+   * @param exhibitionId 조회할 전시회 ID
+   * @return 해당 전시회의 모든 리뷰 목록
+   */
+  List<ReviewResponse> getReviewByExhibitionId(Long exhibitionId);
+
+  /**
+   * 특정 전시회에 등록된 리뷰를 수정합니다.
+   *
+   * @param exhibitionId 리뷰가 속한 전시회 ID
+   * @param reviewId 수정할 리뷰 ID
+   * @param request 리뷰 수정 요청 데이터
+   * @return 수정된 리뷰의 응답 DTO
+   */
+  ReviewResponse updateReview(Long exhibitionId, Long reviewId, ReviewRequest request);
+
+  /**
+   * 특정 전시회에 등록된 리뷰를 삭제합니다.
+   *
+   * @param exhibitionId 리뷰가 속한 전시회 ID
+   * @param reviewId 삭제할 리뷰 ID
+   * @return 삭제 완료 메시지 문자열
+   */
+  String deleteReview(Long exhibitionId, Long reviewId);
+}

--- a/src/main/java/com/likelion13/artium/domain/review/service/ReviewService.java
+++ b/src/main/java/com/likelion13/artium/domain/review/service/ReviewService.java
@@ -3,10 +3,11 @@
  */
 package com.likelion13.artium.domain.review.service;
 
-import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
 import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
+import com.likelion13.artium.global.page.response.PageResponse;
 
 /**
  * 리뷰 관련 주요 기능을 제공하는 서비스 인터페이스입니다.
@@ -37,7 +38,7 @@ public interface ReviewService {
    * @param exhibitionId 조회할 전시회 ID
    * @return 해당 전시회의 모든 리뷰 목록
    */
-  List<ReviewResponse> getReviewByExhibitionId(Long exhibitionId);
+  PageResponse<ReviewResponse> getReviewByExhibitionId(Long exhibitionId, Pageable pageable);
 
   /**
    * 특정 전시회에 등록된 리뷰를 수정합니다.

--- a/src/main/java/com/likelion13/artium/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/review/service/ReviewServiceImpl.java
@@ -1,0 +1,112 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.review.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.exhibition.exception.ExhibitionErrorCode;
+import com.likelion13.artium.domain.exhibition.repository.ExhibitionRepository;
+import com.likelion13.artium.domain.review.dto.request.ReviewRequest;
+import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
+import com.likelion13.artium.domain.review.entity.Review;
+import com.likelion13.artium.domain.review.exception.ReviewErrorCode;
+import com.likelion13.artium.domain.review.mapper.ReviewMapper;
+import com.likelion13.artium.domain.review.repository.ReviewRepository;
+import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.domain.user.service.UserService;
+import com.likelion13.artium.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+  private final UserService userService;
+  private final ReviewRepository reviewRepository;
+  private final ExhibitionRepository exhibitionRepository;
+  private final ReviewMapper reviewMapper;
+
+  @Override
+  @Transactional
+  public ReviewResponse createReview(Long exhibitionId, ReviewRequest request) {
+
+    User currentUser = userService.getCurrentUser();
+
+    Exhibition exhibition =
+        exhibitionRepository
+            .findById(exhibitionId)
+            .orElseThrow(() -> new CustomException(ExhibitionErrorCode.EXHIBITION_NOT_FOUND));
+
+    Review review = reviewMapper.toReview(request, exhibition, currentUser);
+
+    reviewRepository.save(review);
+
+    return reviewMapper.toReviewResponse(review);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public List<ReviewResponse> getReviewByExhibitionId(Long exhibitionId) {
+
+    exhibitionRepository
+        .findById(exhibitionId)
+        .orElseThrow(() -> new CustomException(ExhibitionErrorCode.EXHIBITION_NOT_FOUND));
+
+    List<Review> reviews = reviewRepository.findByExhibitionId(exhibitionId);
+
+    return reviews.stream().map(reviewMapper::toReviewResponse).toList();
+  }
+
+  @Override
+  @Transactional
+  public ReviewResponse updateReview(Long exhibitionId, Long reviewId, ReviewRequest request) {
+
+    User currentUser = userService.getCurrentUser();
+
+    Exhibition exhibition =
+        exhibitionRepository
+            .findById(exhibitionId)
+            .orElseThrow(() -> new CustomException(ExhibitionErrorCode.EXHIBITION_NOT_FOUND));
+
+    Review review =
+        reviewRepository
+            .findById(reviewId)
+            .orElseThrow(() -> new CustomException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+    if (!review.getUser().getId().equals(currentUser.getId())) {
+      throw new CustomException(ReviewErrorCode.REVIEW_ACCESS_DENIED);
+    }
+
+    review.update(request.getContent());
+
+    return reviewMapper.toReviewResponse(review);
+  }
+
+  @Override
+  @Transactional
+  public String deleteReview(Long exhibitionId, Long reviewId) {
+
+    User currentUser = userService.getCurrentUser();
+
+    Review review =
+        reviewRepository
+            .findById(reviewId)
+            .orElseThrow(() -> new CustomException(ReviewErrorCode.REVIEW_NOT_FOUND));
+
+    if (!review.getUser().getId().equals(currentUser.getId())) {
+      throw new CustomException(ReviewErrorCode.REVIEW_ACCESS_DENIED);
+    }
+
+    reviewRepository.delete(review);
+
+    return "리뷰가 성공적으로 삭제되었습니다.";
+  }
+}

--- a/src/main/java/com/likelion13/artium/domain/user/entity/User.java
+++ b/src/main/java/com/likelion13/artium/domain/user/entity/User.java
@@ -24,6 +24,7 @@ import com.likelion13.artium.domain.exhibition.mapping.ExhibitionLike;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionParticipant;
 import com.likelion13.artium.domain.piece.entity.Piece;
 import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
+import com.likelion13.artium.domain.review.entity.Review;
 import com.likelion13.artium.domain.user.mapping.UserLike;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
@@ -86,6 +87,10 @@ public class User extends BaseTimeEntity {
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
   private List<ExhibitionLike> exhibitionLikes = new ArrayList<>();
+
+  @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<Review> reviews = new ArrayList<>();
 
   // 내가 좋아요 한 사용자
   @OneToMany(mappedBy = "liker", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/likelion13/artium/global/page/mapper/PageMapper.java
+++ b/src/main/java/com/likelion13/artium/global/page/mapper/PageMapper.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceSummaryResponse;
+import com.likelion13.artium.domain.review.dto.response.ReviewResponse;
 import com.likelion13.artium.global.page.response.PageResponse;
 
 @Component
@@ -30,6 +31,10 @@ public class PageMapper {
   }
 
   public PageResponse<PieceSummaryResponse> toPiecePageResponse(Page<PieceSummaryResponse> page) {
+    return toPageResponse(page);
+  }
+
+  public PageResponse<ReviewResponse> toReviewPageResponse(Page<ReviewResponse> page) {
     return toPageResponse(page);
   }
 }


### PR DESCRIPTION
## ✨ 새로운 기능
- 감상평 관련 전체 기능 작업

## 🛠 개발 상세
- 감상평 기본 CRUD

## 🔗 관련 문서 / 이슈
- close: #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 전시별 감상평 작성·조회(페이징)·수정·삭제 기능 추가
  - 감상평 응답에 작성 시각(createdAt) 및 본인 작성 여부(isAuthor) 포함

- 개선
  - 전시 설명 필드 및 오프라인 설명에 긴 텍스트(TEXT) 지원 추가
  - 감상평 조회에 페이징(pagination) 적용

- 문서
  - 전시 감상평 API 스펙(오픈API/스웨거) 문서화 및 예시 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->