### PR TITLE
✨ Feat: 좋아요 한 작품 리스트, 좋아요 기반 추천 작품 리스트 기능 추가(+작품 승인, 거절)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,10 +3,13 @@ on:
   push:
     branches:
       - main
+      - develop
 
 jobs:
   build:
     runs-on: self-hosted
+    outputs:
+      profile: ${{ steps.set-profile.outputs.profile }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,9 +29,23 @@ jobs:
       - name: Grant execute permission for Gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
+      - name: Set Spring profile by branch
+        id: set-profile
         run: |
-          ./gradlew clean bootjar -Pprofile=dev
+            if [ "${GITHUB_REF##*/}" = "develop" ]; then
+              echo "PROFILE=dev" >> $GITHUB_ENV
+              echo "profile=dev" >> $GITHUB_OUTPUT
+            elif [ "${GITHUB_REF##*/}" = "main" ]; then
+              echo "PROFILE=prod" >> $GITHUB_ENV
+              echo "profile=prod" >> $GITHUB_OUTPUT
+            else
+              # 안전한 기본값
+              echo "PROFILE=dev" >> $GITHUB_ENV
+              echo "profile=dev" >> $GITHUB_OUTPUT
+            fi
+
+      - name: Build with Gradle
+        run: ./gradlew clean bootjar -Pprofile=${PROFILE}
 
       - name: Docker build & push
         run: |
@@ -44,13 +61,22 @@ jobs:
 
       - name: Deploy on server
         uses: appleboy/ssh-action@master
+        env:
+          PROFILE: ${{ needs.build.outputs.profile }}
         with:
+          envs: PROFILE
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script: |
-            echo "${{ secrets.ENV_FILE }}" > /home/ubuntu/actions-runner/_work/artium-be/artium-be/.env
+            if [ "${PROFILE}" = "dev" ]; then
+              printf '%s\n' "${{ secrets.ENV_DEV }}" > /home/ubuntu/actions-runner/_work/artium-be/artium-be/.env
+            elif [ "${PROFILE}" = "prod" ]; then
+              printf '%s\n' "${{ secrets.ENV_PROD }}" > /home/ubuntu/actions-runner/_work/artium-be/artium-be/.env
+            fi
+            echo "PROFILE=${PROFILE}" >> /home/ubuntu/actions-runner/_work/artium-be/artium-be/.env
+            
             cd /home/ubuntu/actions-runner/_work/artium-be/artium-be
             docker compose down
             docker compose pull

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,7 @@ out/
 !**/src/test/**/out/
 src/main/resources/*.properties
 src/main/resources/*.yml
-.env
+.env.*
 
 ### NetBeans ###
 /nbproject/private/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ COPY --from=build /app/build/libs/*.jar app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "exec java -jar app.jar --spring.profiles.active=${SPRING_PROFILES_ACTIVE:-dev}"]

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -47,6 +48,9 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // Spring Ai
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.1'
 
     // OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'

--- a/build.gradle
+++ b/build.gradle
@@ -89,4 +89,14 @@ spotless {
     }
 }
 
-def springProfile = project.findProperty("spring.profiles.active") ?: ""
+def profile = project.findProperty("profile") ?: "dev"
+
+bootRun {
+    systemProperty "spring.profiles.active", profile
+}
+
+tasks.named('bootJar') {
+    doFirst {
+        println ">>> Building with Spring profile: $profile"
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,11 +7,11 @@ services:
     ports:
       - "8080:8080"
     environment:
-      SPRING_PROFILES_ACTIVE: dev
-      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/artium
+      SPRING_PROFILES_ACTIVE: ${PROFILE}
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/artium_${PROFILE:-dev}
       SPRING_DATASOURCE_USERNAME: ${DB_USER}
       SPRING_DATASOURCE_PASSWORD: ${DB_PASS}
-    command: ["java", "-Dspring.profiles.active=dev", "-jar", "app.jar"]
+    command: ["java", "-Dspring.profiles.active=${PROFILE:-dev}", "-jar", "app.jar"]
     depends_on:
       - mysql
       - redis
@@ -25,7 +25,7 @@ services:
     ports:
       - "3306:3306"
     environment:
-      MYSQL_DATABASE: artium
+      MYSQL_DATABASE: artium_${PROFILE:-dev}
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASS}
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASS}

--- a/src/main/java/com/likelion13/artium/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/likelion13/artium/domain/auth/controller/AuthController.java
@@ -18,7 +18,7 @@ import com.likelion13.artium.global.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Auth", description = "A 관리 API")
+@Tag(name = "인증", description = "인증 관련 API")
 @RequestMapping("/api/auths")
 public interface AuthController {
 
@@ -28,6 +28,6 @@ public interface AuthController {
       HttpServletResponse response, @RequestBody @Valid LoginRequest loginRequest);
 
   @PostMapping("/logout")
-  @Operation(summary = "로그아웃", description = "로그아웃을 수행하여 사용자의 Redis RT 삭제 + 액세스 토큰 블랙리스트를 처리힙니다.")
+  @Operation(summary = "로그아웃", description = "로그아웃을 수행하여 사용자의 Redis RT 삭제 + 액세스 토큰 블랙리스트를 처리합니다.")
   ResponseEntity<BaseResponse<String>> logout(@RequestHeader("Authorization") String header);
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceController.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceController.java
@@ -87,4 +87,18 @@ public interface PieceController {
   @Operation(summary = "임시저장된 작품 개수 조회", description = "사용자가 임시 저장한 작품의 총 개수를 반환하기 위한 API")
   @GetMapping("/draft-count")
   ResponseEntity<BaseResponse<Integer>> getPieceDraftCount();
+
+  @Operation(summary = "좋아요 한 작품 리스트 조회", description = "사용자가 좋아요 한 작품의 리스트를 반환하는 API")
+  @GetMapping("/likes")
+  ResponseEntity<BaseResponse<PageResponse<PieceSummaryResponse>>> getLikePieces(
+      @Parameter(description = "페이지 번호", example = "1") @RequestParam Integer pageNum,
+      @Parameter(description = "페이지 크기", example = "3") @RequestParam Integer pageSize);
+
+  @Operation(
+      summary = "취향 기반 추천 작품 리스트 조회",
+      description = "사용자가 좋아요 한 작품을 기반으로 추천 작품 리스트를 조회하기 위한 API")
+  @GetMapping("/recommendations")
+  ResponseEntity<BaseResponse<PageResponse<PieceSummaryResponse>>> getRecommendationPieces(
+      @Parameter(description = "페이지 번호", example = "1") @RequestParam Integer pageNum,
+      @Parameter(description = "페이지 크기", example = "3") @RequestParam Integer pageSize);
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
@@ -41,9 +41,8 @@ public class PieceControllerImpl implements PieceController {
       @RequestParam Long userId, @RequestParam Integer pageNum, @RequestParam Integer pageSize) {
     Pageable pageable = validatePageable(pageNum, pageSize);
 
-    return ResponseEntity.ok(
-        BaseResponse.success(
-            200, "작품 리스트 조회에 성공했습니다.", pieceService.getPiecePage(userId, pageable)));
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(pieceService.getPiecePage(userId, pageable)));
   }
 
   @Operation(summary = "내 작품 리스트 조회 API", description = "내 작품 리스트를 조회하기 위한 API")
@@ -55,9 +54,8 @@ public class PieceControllerImpl implements PieceController {
 
     Pageable pageable = validatePageable(pageNum, pageSize);
 
-    return ResponseEntity.ok(
-        BaseResponse.success(
-            200, "내 작품 리스트 조회에 성공했습니다.", pieceService.getMyPiecePage(applicated, pageable)));
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(pieceService.getMyPiecePage(applicated, pageable)));
   }
 
   @Override
@@ -69,19 +67,18 @@ public class PieceControllerImpl implements PieceController {
 
     if (detailImages != null && detailImages.size() > 5)
       throw new CustomException(PieceErrorCode.TOO_MANY_DETAIL_IMAGES);
-    PieceSummaryResponse pieceSummaryResponse =
-        pieceService.createPiece(createPieceRequest, saveStatus, mainImage, detailImages);
 
-    return ResponseEntity.ok(BaseResponse.success(201, "작품 등록에 성공했습니다.", pieceSummaryResponse));
+    return ResponseEntity.status(201)
+        .body(
+            BaseResponse.success(
+                pieceService.createPiece(createPieceRequest, saveStatus, mainImage, detailImages)));
   }
 
   @Override
   public ResponseEntity<BaseResponse<PieceResponse>> getPiece(
       @PathVariable(value = "piece-id") Long pieceId) {
 
-    PieceResponse pieceResponse = pieceService.getPiece(pieceId);
-
-    return ResponseEntity.ok(BaseResponse.success(200, "작품 조회에 성공했습니다.", pieceResponse));
+    return ResponseEntity.status(200).body(BaseResponse.success(pieceService.getPiece(pieceId)));
   }
 
   @Override
@@ -98,26 +95,43 @@ public class PieceControllerImpl implements PieceController {
             : updatePieceRequest.getRemainPieceDetailIds().size();
     if (detailImages != null && remainCount + detailImages.size() > 5)
       throw new CustomException(PieceErrorCode.TOO_MANY_DETAIL_IMAGES);
-    PieceResponse pieceResponse =
-        pieceService.updatePiece(pieceId, updatePieceRequest, saveStatus, mainImage, detailImages);
 
-    return ResponseEntity.ok(BaseResponse.success(200, "작품 수정에 성공했습니다.", pieceResponse));
+    return ResponseEntity.status(200)
+        .body(
+            BaseResponse.success(
+                pieceService.updatePiece(
+                    pieceId, updatePieceRequest, saveStatus, mainImage, detailImages)));
   }
 
   @Override
   public ResponseEntity<BaseResponse<String>> deletePiece(
       @PathVariable(value = "piece-id") Long pieceId) {
 
-    pieceService.deletePiece(pieceId);
-
-    return ResponseEntity.ok(BaseResponse.success(pieceId + "번 식별자 작품이 정상적으로 삭제되었습니다."));
+    return ResponseEntity.status(204).body(BaseResponse.success(pieceService.deletePiece(pieceId)));
   }
 
   @Override
   public ResponseEntity<BaseResponse<Integer>> getPieceDraftCount() {
 
-    return ResponseEntity.ok(
-        BaseResponse.success(200, "임시저장 작품 개수 조회에 성공했습니다.", pieceService.getPieceDraftCount()));
+    return ResponseEntity.status(200).body(BaseResponse.success(pieceService.getPieceDraftCount()));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<PageResponse<PieceSummaryResponse>>> getLikePieces(
+      @RequestParam Integer pageNum, @RequestParam Integer pageSize) {
+    Pageable pageable = validatePageable(pageNum, pageSize);
+
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(pieceService.getLikePieces(pageable)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<PageResponse<PieceSummaryResponse>>> getRecommendationPieces(
+      @RequestParam Integer pageNum, @RequestParam Integer pageSize) {
+    Pageable pageable = validatePageable(pageNum, pageSize);
+
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(pieceService.getRecommendationPiecePage(pageable)));
   }
 
   private Pageable validatePageable(Integer pageNum, Integer pageSize) {

--- a/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
@@ -85,6 +85,10 @@ public class Piece extends BaseTimeEntity {
     this.saveStatus = saveStatus;
   }
 
+  public void updateProgressStatus(ProgressStatus progressStatus) {
+    this.progressStatus = progressStatus;
+  }
+
   public String updateImageUrl(String imageUrl) {
     String oldImageUrl = this.imageUrl;
     this.imageUrl = imageUrl;

--- a/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
@@ -17,12 +17,22 @@ import com.likelion13.artium.domain.piece.entity.SaveStatus;
 
 public interface PieceRepository extends JpaRepository<Piece, Long> {
 
+  Page<Piece> findByIdIn(List<Long> ids, Pageable pageable);
+
+  List<Piece> findByUser_Id(Long userId);
+
   @Query("SELECT p FROM Piece p WHERE p.user.id = :userId")
   Page<Piece> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
   @Query("SELECT p FROM Piece p WHERE p.user.id = :userId AND p.progressStatus IN :statuses")
   Page<Piece> findByUserIdAndProgressStatusIn(
       @Param("userId") Long userId,
+      @Param("statuses") List<ProgressStatus> statuses,
+      Pageable pageable);
+
+  @Query("SELECT p.id FROM Piece p WHERE p.id In :pieceIds AND p.progressStatus IN :statuses")
+  Page<Long> findIdsByIdsInAndProgressStatusIn(
+      @Param("pieceIds") List<Long> pieceIds,
       @Param("statuses") List<ProgressStatus> statuses,
       Pageable pageable);
 

--- a/src/main/java/com/likelion13/artium/domain/piece/service/PieceService.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/service/PieceService.java
@@ -67,11 +67,28 @@ public interface PieceService {
 
   /**
    * @param pieceId 작품 식별자 (크리에이터가 아닐 시 삭제 실패)
+   * @return 작품 삭제 성공 메시지
    */
-  void deletePiece(Long pieceId);
+  String deletePiece(Long pieceId);
 
   /**
    * @return 임시 저장된 작품의 개수 (크리에이터가 아닐 시 조회 실패)
    */
   Integer getPieceDraftCount();
+
+  /**
+   * 좋아요 한 작품 리스트 조회 메서드
+   *
+   * @param pageable 페이징 처리값 객체
+   * @return 좋아요 한 작품 리스트
+   */
+  PageResponse<PieceSummaryResponse> getLikePieces(Pageable pageable);
+
+  /**
+   * 좋아요 기반 추천 작품 리스트 조회 메서드
+   *
+   * @param pageable 페이징 처리값 객체
+   * @return 추천 작품 리스트
+   */
+  PageResponse<PieceSummaryResponse> getRecommendationPiecePage(Pageable pageable);
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/service/PieceServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/service/PieceServiceImpl.java
@@ -3,7 +3,10 @@
  */
 package com.likelion13.artium.domain.piece.service;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -26,13 +29,17 @@ import com.likelion13.artium.domain.piece.mapper.PieceMapper;
 import com.likelion13.artium.domain.piece.repository.PieceRepository;
 import com.likelion13.artium.domain.pieceDetail.entity.PieceDetail;
 import com.likelion13.artium.domain.pieceDetail.service.PieceDetailService;
+import com.likelion13.artium.domain.pieceLike.exception.PieceLikeErrorCode;
 import com.likelion13.artium.domain.pieceLike.repository.PieceLikeRepository;
 import com.likelion13.artium.domain.user.exception.UserErrorCode;
 import com.likelion13.artium.domain.user.repository.UserRepository;
 import com.likelion13.artium.domain.user.service.UserService;
+import com.likelion13.artium.global.ai.vector.VectorUtils;
 import com.likelion13.artium.global.exception.CustomException;
 import com.likelion13.artium.global.page.mapper.PageMapper;
 import com.likelion13.artium.global.page.response.PageResponse;
+import com.likelion13.artium.global.qdrant.entity.CollectionName;
+import com.likelion13.artium.global.qdrant.service.QdrantService;
 import com.likelion13.artium.global.s3.entity.PathName;
 import com.likelion13.artium.global.s3.service.S3Service;
 
@@ -52,6 +59,7 @@ public class PieceServiceImpl implements PieceService {
   private final UserService userService;
   private final PageMapper pageMapper;
   private final UserRepository userRepository;
+  private final QdrantService qdrantService;
 
   @Override
   public PageResponse<PieceSummaryResponse> getPiecePage(Long userId, Pageable pageable) {
@@ -238,7 +246,7 @@ public class PieceServiceImpl implements PieceService {
 
   @Override
   @Transactional
-  public void deletePiece(Long pieceId) {
+  public String deletePiece(Long pieceId) {
     Long userId = userService.getCurrentUser().getId();
 
     Piece piece =
@@ -260,6 +268,8 @@ public class PieceServiceImpl implements PieceService {
                 s3Service.deleteFile(s3Service.extractKeyNameFromUrl(pieceDetail.getImageUrl())));
 
     pieceRepository.delete(piece);
+
+    return piece.getId() + "번 작품 삭제에 성공했습니다.";
   }
 
   @Override
@@ -267,6 +277,89 @@ public class PieceServiceImpl implements PieceService {
 
     return pieceRepository.countByUserIdAndSaveStatus(
         userService.getCurrentUser().getId(), SaveStatus.DRAFT);
+  }
+
+  @Override
+  public PageResponse<PieceSummaryResponse> getLikePieces(Pageable pageable) {
+    Long userId = userService.getCurrentUser().getId();
+
+    Pageable sortedPageable =
+        PageRequest.of(
+            pageable.getPageNumber(), pageable.getPageSize(), Sort.by(Direction.DESC, "createdAt"));
+
+    Page<PieceSummaryResponse> page =
+        pieceLikeRepository
+            .findPieceByUser_Id(userId, sortedPageable)
+            .map(pieceMapper::toPieceSummaryResponse);
+
+    return pageMapper.toPiecePageResponse(page);
+  }
+
+  @Override
+  public PageResponse<PieceSummaryResponse> getRecommendationPiecePage(Pageable pageable) {
+    Long userId = userService.getCurrentUser().getId();
+
+    Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+
+    List<Long> recommendPieceIds = recommendPieceIds(userId, 50);
+
+    Page<PieceSummaryResponse> page =
+        pieceRepository
+            .findByIdIn(recommendPieceIds, sortedPageable)
+            .map(pieceMapper::toPieceSummaryResponse);
+
+    return pageMapper.toPiecePageResponse(page);
+  }
+
+  private List<Long> recommendPieceIds(Long userId, int topN) {
+    int limit = (topN < 0) ? 50 : topN;
+
+    List<Long> likeIds = pieceLikeRepository.findIdsByUser_Id(userId);
+
+    if (likeIds == null || likeIds.isEmpty()) {
+      throw new CustomException(PieceLikeErrorCode.PIECE_LIKE_NOT_FOUND);
+    }
+
+    List<float[]> likeVecs = qdrantService.retrieveVectorsByIds(likeIds, CollectionName.PIECE);
+    float[] userVector = VectorUtils.normalize(VectorUtils.mean(likeVecs));
+
+    List<Long> excludeIds = new ArrayList<>(likeIds);
+    List<Long> myPieceIds =
+        pieceRepository.findByUser_Id(userId).stream().map(Piece::getId).toList();
+    excludeIds.addAll(myPieceIds);
+
+    List<Map<String, Object>> result =
+        qdrantService.search(userVector, limit, excludeIds, CollectionName.PIECE);
+
+    List<Map<String, Object>> sorted = new ArrayList<>(result);
+    sorted.sort(
+        (a, b) -> {
+          double sb = ((Number) b.get("score")).doubleValue();
+          double sa = ((Number) a.get("score")).doubleValue();
+          return Double.compare(sb, sa);
+        });
+    sorted = sorted.subList(0, Math.min(limit, sorted.size()));
+
+    List<Long> candidateIds =
+        sorted.stream()
+            .map(m -> (Map<String, Object>) m.get("payload"))
+            .filter(Objects::nonNull)
+            .map(p -> ((Number) p.get("pieceId")).longValue())
+            .toList();
+
+    List<Long> recommendIds =
+        candidateIds.isEmpty()
+            ? List.of()
+            : pieceRepository
+                .findIdsByIdsInAndProgressStatusIn(
+                    candidateIds,
+                    List.of(ProgressStatus.REGISTERED, ProgressStatus.ON_DISPLAY),
+                    Pageable.unpaged())
+                .getContent()
+                .stream()
+                .toList();
+
+    return recommendIds;
   }
 
   private boolean validateCreatePieceFields(

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/controller/PieceLikeControllerImpl.java
@@ -24,17 +24,15 @@ public class PieceLikeControllerImpl implements PieceLikeController {
   public ResponseEntity<BaseResponse<PieceLikeResponse>> likePiece(
       @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId) {
 
-    PieceLikeResponse pieceLikeResponse = pieceLikeService.likePiece(pieceId);
-
-    return ResponseEntity.ok(BaseResponse.success(201, "작품 좋아요 등록에 성공했습니다.", pieceLikeResponse));
+    return ResponseEntity.status(201)
+        .body(BaseResponse.success(pieceLikeService.likePiece(pieceId)));
   }
 
   @Override
   public ResponseEntity<BaseResponse<PieceLikeResponse>> unlikePiece(
       @Parameter(description = "특정 작품 ID") @PathVariable(value = "piece-id") Long pieceId) {
 
-    PieceLikeResponse pieceLikeResponse = pieceLikeService.unlikePiece(pieceId);
-
-    return ResponseEntity.ok(BaseResponse.success(200, "작품 좋아요 취소에 성공했습니다.", pieceLikeResponse));
+    return ResponseEntity.status(204)
+        .body(BaseResponse.success(pieceLikeService.unlikePiece(pieceId)));
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/exception/PieceLikeErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/exception/PieceLikeErrorCode.java
@@ -14,7 +14,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum PieceLikeErrorCode implements BaseErrorCode {
   ALREADY_LIKED("PIECE_LIKE_4091", "이미 좋아요 상태입니다.", HttpStatus.CONFLICT),
-  NOT_LIKED("PIECE_LIKE_4092", "좋아요한 상태가 아닙니다.", HttpStatus.CONFLICT);
+  NOT_LIKED("PIECE_LIKE_4092", "좋아요한 상태가 아닙니다.", HttpStatus.CONFLICT),
+  PIECE_LIKE_NOT_FOUND("PIECE_LIKE_4041", "좋아요 목록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  SELF_LIKE_NOT_ALLOWRED("PIECE_LIKE_4001", "본인 작품은 좋아요 할 수 없습니다.", HttpStatus.BAD_REQUEST);
 
   private final String code;
   private final String message;

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/repository/PieceLikeRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/repository/PieceLikeRepository.java
@@ -3,13 +3,25 @@
  */
 package com.likelion13.artium.domain.pieceLike.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import com.likelion13.artium.domain.piece.entity.Piece;
 import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 
 public interface PieceLikeRepository extends JpaRepository<PieceLike, Long> {
 
   Optional<PieceLike> findByUser_IdAndPiece_Id(Long userId, Long pieceId);
+
+  @Query("SELECT pl.piece.id from PieceLike pl where pl.user.id= :userId")
+  List<Long> findIdsByUser_Id(@Param("userId") Long userId);
+
+  @Query("SELECT pl.piece from PieceLike pl where pl.user.id= :userId")
+  Page<Piece> findPieceByUser_Id(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/pieceLike/service/PieceLikeServiceImpl.java
@@ -44,6 +44,11 @@ public class PieceLikeServiceImpl implements PieceLikeService {
         pieceRepository
             .findById(pieceId)
             .orElseThrow(() -> new CustomException(PieceErrorCode.PIECE_NOT_FOUND));
+
+    if (piece.getUser().getId().equals(user.getId())) {
+      throw new CustomException(PieceLikeErrorCode.SELF_LIKE_NOT_ALLOWRED);
+    }
+
     try {
       PieceLike pieceLike = PieceLike.builder().piece(piece).user(user).build();
 

--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserController.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserController.java
@@ -91,4 +91,14 @@ public interface UserController {
   @GetMapping("/devs")
   @Operation(summary = "[개발자]사용자 전체 조회", description = "스웨거를 사용해 전체 사용자를 조회합니다.")
   ResponseEntity<BaseResponse<List<UserDetailResponse>>> getAllUsers();
+
+  @PutMapping("/{piece-id}/approve")
+  @Operation(summary = "[관리자]등록 신청한 작품 승인", description = "사용자가 등록 신청한 작품을 승인합니다.")
+  ResponseEntity<BaseResponse<String>> approvePiece(
+      @Parameter(description = "작품 식별자", example = "1") Long pieceId);
+
+  @PutMapping("/{piece-id}/reject")
+  @Operation(summary = "[관리자]등록 신청한 작품 거절", description = "사용자가 등록 신청한 작품을 거절합니다.")
+  ResponseEntity<BaseResponse<String>> rejectPiece(
+      @Parameter(description = "작품 식별자", example = "1") Long pieceId);
 }

--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserController.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserController.java
@@ -3,17 +3,25 @@
  */
 package com.likelion13.artium.domain.user.controller;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
 import com.likelion13.artium.global.response.BaseResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +29,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "User", description = "User 관리 API")
+@Tag(name = "사용자", description = "사용자 관련 API")
 @RequestMapping("/api/users")
 public interface UserController {
 
@@ -39,4 +47,48 @@ public interface UserController {
               content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
           @RequestPart(value = "image")
           MultipartFile image);
+
+  @PostMapping("/like")
+  @Operation(summary = "사용자 좋아요", description = "좋아요 할 사용자의 식별자를 요청 받아 좋아요를 등록합니다.")
+  ResponseEntity<BaseResponse<LikeResponse>> createUserLike(
+      @Parameter(description = "좋아요 할 사용자 식별자", example = "1") @RequestParam Long userId);
+
+  @GetMapping
+  @Operation(summary = "사용자 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
+  ResponseEntity<BaseResponse<UserDetailResponse>> getUserDetail();
+
+  @GetMapping("/check")
+  @Operation(
+      summary = "닉네임 중복 여부 확인",
+      description =
+          """
+              사용자가 입력한 닉네임이 이미 존재하는지 여부를 반환합니다.
+              true -> 중복되는 닉네임, 변경할 수 없음.
+              false -> 중복되지 않는 닉네임, 변경 가능.
+              """)
+  ResponseEntity<BaseResponse<Boolean>> checkNicknameDuplicated(
+      @Parameter(description = "확인할 닉네임", example = "아르티움") @RequestParam String nickname);
+
+  @PutMapping("/nickname")
+  @Operation(summary = "닉네임 변경", description = "현재 로그인된 사용자의 닉네임을 변경합니다.")
+  ResponseEntity<BaseResponse<String>> updateNickname(
+      @Parameter(description = "변경할 닉네임", example = "아르티움") @RequestParam String newNickname);
+
+  @PutMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  @Operation(summary = "프로필 사진 변경", description = "현재 로그인된 사용자의 프로필 사진을 변경합니다.")
+  ResponseEntity<BaseResponse<String>> updateProfileImage(
+      @Parameter(description = "새로운 프로필 사진") @RequestPart MultipartFile profileImage);
+
+  @DeleteMapping
+  @Operation(summary = "사용자 탈퇴", description = "현재 로그인된 사용자를 Soft Delete 처리합니다.")
+  ResponseEntity<BaseResponse<String>> deleteUser();
+
+  @DeleteMapping("/like")
+  @Operation(summary = "사용자 좋아요 취소", description = "좋아요 했던 사용자의 식별자를 요청 받아 좋아요를 취소합니다.")
+  ResponseEntity<BaseResponse<LikeResponse>> deleteUserLike(
+      @Parameter(description = "좋아요 했던 사용자 식별자", example = "1") @RequestParam Long userId);
+
+  @GetMapping("/devs")
+  @Operation(summary = "[개발자]사용자 전체 조회", description = "스웨거를 사용해 전체 사용자를 조회합니다.")
+  ResponseEntity<BaseResponse<List<UserDetailResponse>>> getAllUsers();
 }

--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
@@ -88,4 +88,16 @@ public class UserControllerImpl implements UserController {
 
     return ResponseEntity.ok(BaseResponse.success(userDetailResponses));
   }
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> approvePiece(Long pieceId) {
+
+    return ResponseEntity.status(200).body(BaseResponse.success(userService.approvePiece(pieceId)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> rejectPiece(Long pieceId) {
+
+    return ResponseEntity.status(200).body(BaseResponse.success(userService.rejectPiece(pieceId)));
+  }
 }

--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
@@ -3,15 +3,20 @@
  */
 package com.likelion13.artium.domain.user.controller;
 
+import java.util.List;
+
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
 import com.likelion13.artium.domain.user.service.UserService;
 import com.likelion13.artium.global.response.BaseResponse;
 
@@ -31,5 +36,56 @@ public class UserControllerImpl implements UserController {
     SignUpResponse signUpResponse = userService.signUp(signUpRequest, image);
 
     return ResponseEntity.ok(BaseResponse.success(201, "회원가입에 성공하였습니다.", signUpResponse));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<LikeResponse>> createUserLike(@RequestParam Long userId) {
+
+    return ResponseEntity.ok(
+        BaseResponse.success(201, "사용자 좋아요에 성공하였습니다.", userService.createUserLike(userId)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<UserDetailResponse>> getUserDetail() {
+
+    return ResponseEntity.ok(BaseResponse.success(userService.getUserDetail()));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<Boolean>> checkNicknameDuplicated(
+      @RequestParam String nickname) {
+    return ResponseEntity.ok(BaseResponse.success(userService.checkNicknameDuplicated(nickname)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> updateNickname(@RequestParam String newNickname) {
+    return ResponseEntity.ok(BaseResponse.success(userService.updateNickname(newNickname)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> updateProfileImage(
+      @RequestPart MultipartFile profileImage) {
+
+    return ResponseEntity.ok(BaseResponse.success(userService.updateProfileImage(profileImage)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> deleteUser() {
+
+    return ResponseEntity.ok(BaseResponse.success(userService.deleteUser()));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<LikeResponse>> deleteUserLike(@RequestParam Long userId) {
+
+    return ResponseEntity.ok(BaseResponse.success(userService.deleteUserLike(userId)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<List<UserDetailResponse>>> getAllUsers() {
+
+    List<UserDetailResponse> userDetailResponses = userService.getAllUsers();
+
+    return ResponseEntity.ok(BaseResponse.success(userDetailResponses));
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/LikeResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/LikeResponse.java
@@ -1,0 +1,20 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "LikeResponse DTO", description = "사용자 좋아요 요청에 대한 응답 반환")
+public class LikeResponse {
+
+  @Schema(description = "좋아요를 보낸 사용자 닉네임", example = "윤희준")
+  private String currentUserNickname;
+
+  @Schema(description = "좋아요를 받은 사용자 닉네임", example = "금시언")
+  private String targetUserNickname;
+}

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/UserDetailResponse.java
@@ -1,0 +1,42 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.user.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "UserDetailResponse DTO", description = "사용자 정보 응답 반환")
+public class UserDetailResponse {
+
+  @Schema(description = "사용자 식별자", example = "1")
+  private Long userId;
+
+  @Schema(description = "아이디(이메일)", example = "example@example.com")
+  private String username;
+
+  @Schema(description = "닉네임", example = "나나나난")
+  private String nickname;
+
+  @Schema(
+      description = "프로필 이미지 URL",
+      example = "http://k.kakaocdn.net/dn/oOPCG/btsPjlOHjk6/6jx0PyBKkHHyCfbV8IY741/img_640x640.jpg")
+  private String profileImageUrl;
+
+  @Schema(description = "참여한 전시 식별자 리스트", example = "[1, 2, 3]")
+  private List<Long> exhibitionParticipantIds;
+
+  @Schema(description = "내가 좋아요 한 사용자 식별자 리스트", example = "[1, 2, 3]")
+  private List<Long> likedUsersIds;
+
+  @Schema(description = "나를 좋아요 한 사용자 식별자 리스트", example = "[1, 2, 3]")
+  private List<Long> likedByUsersIds;
+
+  @Schema(description = "좋아요 한 전시 식별자 리스트", example = "[1, 2, 3]")
+  private List<Long> exhibitionLikeIds;
+}

--- a/src/main/java/com/likelion13/artium/domain/user/entity/User.java
+++ b/src/main/java/com/likelion13/artium/domain/user/entity/User.java
@@ -3,6 +3,7 @@
  */
 package com.likelion13.artium.domain.user.entity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -23,6 +24,7 @@ import com.likelion13.artium.domain.exhibition.mapping.ExhibitionLike;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionParticipant;
 import com.likelion13.artium.domain.piece.entity.Piece;
 import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
+import com.likelion13.artium.domain.user.mapping.UserLike;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
 import lombok.AccessLevel;
@@ -62,6 +64,13 @@ public class User extends BaseTimeEntity {
   @Builder.Default
   private Role role = Role.USER;
 
+  @Column(name = "is_deleted", nullable = false)
+  @Builder.Default
+  private boolean isDeleted = false;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
   @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
   @Builder.Default
   private List<Piece> pieces = new ArrayList<>();
@@ -78,6 +87,16 @@ public class User extends BaseTimeEntity {
   @Builder.Default
   private List<ExhibitionLike> exhibitionLikes = new ArrayList<>();
 
+  // 내가 좋아요 한 사용자
+  @OneToMany(mappedBy = "liker", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<UserLike> likedUsers = new ArrayList<>();
+
+  // 나를 좋아요 한 사용자
+  @OneToMany(mappedBy = "liked", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<UserLike> likedByUsers = new ArrayList<>();
+
   public static User fromOAuth(String email, String nickname, String profileImageUrl) {
     return User.builder()
         .username(email)
@@ -88,9 +107,16 @@ public class User extends BaseTimeEntity {
         .build();
   }
 
-  public void addPiece(Piece piece) {
-    if (piece == null) return;
-    if (this.pieces == null) this.pieces = new ArrayList<>();
-    this.pieces.add(piece);
+  public void updateNickname(String newNickname) {
+    this.nickname = newNickname;
+  }
+
+  public void updateProfileImageUrl(String profileImageUrl) {
+    this.profileImageUrl = profileImageUrl;
+  }
+
+  public void softDelete() {
+    this.isDeleted = true;
+    this.deletedAt = LocalDateTime.now();
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
@@ -14,8 +14,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
   USERNAME_ALREADY_EXISTS("USER_4001", "이미 존재하는 사용자 아이디입니다.", HttpStatus.BAD_REQUEST),
-  USER_NOT_FOUND("USER_4002", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  UNAUTHORIZED("USER_4003", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED);
+  NICKNAME_ALREADY_EXISTS("USER_4002", "이미 존재하는 사용자 닉네임입니다.", HttpStatus.BAD_REQUEST),
+  USER_NOT_FOUND("USER_4003", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  UNAUTHORIZED("USER_4004", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+  CANNOT_LIKE_SELF("USER_4005", "자기 자신은 좋아요 할 수 없습니다.", HttpStatus.BAD_REQUEST),
+  ALREADY_LIKED("USER_4006", "이미 좋아요한 사용자입니다.", HttpStatus.BAD_REQUEST),
+  LIKE_NOT_FOUND("USER_4007", "좋아요 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  ;
 
   private final String code;
   private final String message;

--- a/src/main/java/com/likelion13/artium/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/user/mapper/UserMapper.java
@@ -3,15 +3,66 @@
  */
 package com.likelion13.artium.domain.user.mapper;
 
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Component;
 
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionLike;
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionParticipant;
+import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
+import com.likelion13.artium.domain.user.entity.Role;
 import com.likelion13.artium.domain.user.entity.User;
 
 @Component
 public class UserMapper {
 
+  public User toUser(SignUpRequest request, String encodedPassword, String imageUrl) {
+    return User.builder()
+        .username(request.getUsername())
+        .password(encodedPassword)
+        .nickname(request.getNickname())
+        .profileImageUrl(imageUrl)
+        .role(Role.USER)
+        .isDeleted(false)
+        .build();
+  }
+
   public SignUpResponse toSignUpResponse(User user) {
     return SignUpResponse.builder().userId(user.getId()).username(user.getUsername()).build();
+  }
+
+  public LikeResponse toLikeResponse(String currentUser, String targetUser) {
+    return LikeResponse.builder()
+        .currentUserNickname(currentUser)
+        .targetUserNickname(targetUser)
+        .build();
+  }
+
+  public UserDetailResponse toUserDetailResponse(User user) {
+    return UserDetailResponse.builder()
+        .userId(user.getId())
+        .username(user.getUsername())
+        .nickname(user.getNickname())
+        .profileImageUrl(user.getProfileImageUrl())
+        .exhibitionParticipantIds(
+            user.getExhibitionParticipants().stream()
+                .map(ExhibitionParticipant::getId)
+                .collect(Collectors.toList()))
+        .likedUsersIds(
+            user.getLikedUsers().stream()
+                .map(userLike -> userLike.getLiked().getId())
+                .collect(Collectors.toList()))
+        .likedByUsersIds(
+            user.getLikedByUsers().stream()
+                .map(userLike -> userLike.getLiker().getId())
+                .collect(Collectors.toList()))
+        .exhibitionLikeIds(
+            user.getExhibitionLikes().stream()
+                .map(ExhibitionLike::getId)
+                .collect(Collectors.toList()))
+        .build();
   }
 }

--- a/src/main/java/com/likelion13/artium/domain/user/mapping/UserLike.java
+++ b/src/main/java/com/likelion13/artium/domain/user/mapping/UserLike.java
@@ -1,0 +1,57 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.domain.user.mapping;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+
+import com.likelion13.artium.domain.user.entity.User;
+import com.likelion13.artium.global.common.BaseTimeEntity;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+    name = "user_like",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uq_user_like_liked_liker",
+          columnNames = {"liked_id", "liker_id"})
+    },
+    indexes = {
+      @Index(name = "idx_user_like_liked_id", columnList = "liked_id"),
+      @Index(name = "idx_user_like_liker_id", columnList = "liker_id")
+    })
+public class UserLike extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 좋아요 보낸 사람
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "liked_id", nullable = false)
+  private User liked;
+
+  // 좋아요 받은 사람
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "liker_id", nullable = false)
+  private User liker;
+}

--- a/src/main/java/com/likelion13/artium/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/user/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByUsername(String username);
 
   boolean existsByUsername(String username);
+
+  boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/likelion13/artium/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion13/artium/domain/user/service/UserService.java
@@ -3,10 +3,14 @@
  */
 package com.likelion13.artium.domain.user.service;
 
+import java.util.List;
+
 import org.springframework.web.multipart.MultipartFile;
 
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
 import com.likelion13.artium.domain.user.entity.User;
 import com.likelion13.artium.global.exception.CustomException;
 
@@ -35,6 +39,14 @@ public interface UserService {
   SignUpResponse signUp(SignUpRequest request, MultipartFile image);
 
   /**
+   * 사용자 좋아요(Like)를 생성합니다.
+   *
+   * @param userId 좋아요를 생성할 대상 사용자 ID
+   * @return 생성된 좋아요 정보를 담은 {@link LikeResponse}
+   */
+  LikeResponse createUserLike(Long userId);
+
+  /**
    * 현재 인증된 사용자의 정보를 조회합니다.
    *
    * <p>인증 정보가 없거나 유효하지 않으면 예외를 던지며, OAuth2 로그인과 자체 로그인 모두 지원합니다.
@@ -43,4 +55,59 @@ public interface UserService {
    * @throws CustomException 인증 실패, 사용자 미존재 시 발생
    */
   User getCurrentUser();
+
+  /**
+   * 현재 인증된 사용자의 상세 정보를 조회합니다.
+   *
+   * @return {@link UserDetailResponse} 현재 인증된 사용자의 상세 정보
+   */
+  UserDetailResponse getUserDetail();
+
+  /**
+   * 닉네임 사용 가능 여부를 확인합니다.
+   *
+   * @param nickname 확인할 닉네임 문자열
+   * @return true이면 사용 가능, false면 중복
+   */
+  Boolean checkNicknameDuplicated(String nickname);
+
+  /**
+   * 사용자의 닉네임을 변경합니다.
+   *
+   * @param newNickname 변경할 새로운 닉네임
+   * @return 변경 완료 메시지 문자열
+   * @throws CustomException 닉네임 중복 등 변경 불가 시 발생
+   */
+  String updateNickname(String newNickname);
+
+  /**
+   * 사용자의 프로필 이미지를 변경합니다.
+   *
+   * @param profileImage 변경할 프로필 이미지 파일
+   * @return 변경 완료 메시지 문자열
+   */
+  String updateProfileImage(MultipartFile profileImage);
+
+  /**
+   * 사용자를 탈퇴 처리합니다.
+   *
+   * @return 탈퇴 완료 메시지 문자열
+   * @throws CustomException 탈퇴 불가 시 발생
+   */
+  String deleteUser();
+
+  /**
+   * 사용자 좋아요(Like)를 삭제합니다.
+   *
+   * @param userId 좋아요를 삭제할 대상 사용자 ID
+   * @return 삭제된 좋아요 정보를 담은 {@link LikeResponse}
+   */
+  LikeResponse deleteUserLike(Long userId);
+
+  /**
+   * 모든 사용자의 상세 정보를 조회합니다.
+   *
+   * @return 모든 사용자의 {@link UserDetailResponse} 목록
+   */
+  List<UserDetailResponse> getAllUsers();
 }

--- a/src/main/java/com/likelion13/artium/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion13/artium/domain/user/service/UserService.java
@@ -110,4 +110,20 @@ public interface UserService {
    * @return 모든 사용자의 {@link UserDetailResponse} 목록
    */
   List<UserDetailResponse> getAllUsers();
+
+  /**
+   * 사용자가 등록 신청한 작품을 승인합니다.
+   *
+   * @param pieceId 작품 식별자
+   * @return 승인 완료 문자열
+   */
+  String approvePiece(Long pieceId);
+
+  /**
+   * 사용자가 등록 신청한 작품을 거절합니다.
+   *
+   * @param pieceId 작품 식별자
+   * @return 거절 완료 문자열
+   */
+  String rejectPiece(Long pieceId);
 }

--- a/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
@@ -16,16 +16,25 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.domain.piece.entity.ProgressStatus;
+import com.likelion13.artium.domain.piece.entity.SaveStatus;
+import com.likelion13.artium.domain.piece.exception.PieceErrorCode;
+import com.likelion13.artium.domain.piece.repository.PieceRepository;
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
 import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
 import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
+import com.likelion13.artium.domain.user.entity.Role;
 import com.likelion13.artium.domain.user.entity.User;
 import com.likelion13.artium.domain.user.exception.UserErrorCode;
 import com.likelion13.artium.domain.user.mapper.UserMapper;
 import com.likelion13.artium.domain.user.mapping.UserLike;
 import com.likelion13.artium.domain.user.repository.UserRepository;
+import com.likelion13.artium.global.ai.embedding.service.EmbeddingService;
 import com.likelion13.artium.global.exception.CustomException;
+import com.likelion13.artium.global.qdrant.entity.CollectionName;
+import com.likelion13.artium.global.qdrant.service.QdrantService;
 import com.likelion13.artium.global.s3.entity.PathName;
 import com.likelion13.artium.global.s3.exception.S3ErrorCode;
 import com.likelion13.artium.global.s3.service.S3Service;
@@ -42,6 +51,9 @@ public class UserServiceImpl implements UserService {
   private final PasswordEncoder passwordEncoder;
   private final UserMapper userMapper;
   private final S3Service s3Service;
+  private final PieceRepository pieceRepository;
+  private final EmbeddingService embeddingService;
+  private final QdrantService qdrantService;
 
   @Override
   @Transactional
@@ -257,5 +269,58 @@ public class UserServiceImpl implements UserService {
     List<User> users = userRepository.findAll();
 
     return users.stream().map(userMapper::toUserDetailResponse).toList();
+  }
+
+  @Override
+  @Transactional
+  public String approvePiece(Long pieceId) {
+    User user = getCurrentUser();
+
+    if (!user.getRole().equals(Role.ADMIN)) {
+      throw new CustomException(UserErrorCode.UNAUTHORIZED);
+    }
+
+    Piece piece =
+        pieceRepository
+            .findById(pieceId)
+            .orElseThrow(() -> new CustomException(PieceErrorCode.PIECE_NOT_FOUND));
+
+    if (!piece.getSaveStatus().equals(SaveStatus.APPLICATION)
+        || !piece.getProgressStatus().equals(ProgressStatus.WAITING)) {
+      throw new CustomException(PieceErrorCode.INVALID_APPLICATION);
+    }
+
+    piece.updateProgressStatus(ProgressStatus.REGISTERED);
+
+    String content = (piece.getTitle() + "\n\n" + piece.getDescription()).trim();
+    float[] vector = embeddingService.embed(content);
+
+    qdrantService.upsertPointUtil(pieceId, vector, piece, CollectionName.PIECE);
+
+    return pieceId + "번 작품 등록을 승인했습니다.";
+  }
+
+  @Override
+  @Transactional
+  public String rejectPiece(Long pieceId) {
+    User user = getCurrentUser();
+
+    if (!user.getRole().equals(Role.ADMIN)) {
+      throw new CustomException(UserErrorCode.UNAUTHORIZED);
+    }
+
+    Piece piece =
+        pieceRepository
+            .findById(pieceId)
+            .orElseThrow(() -> new CustomException(PieceErrorCode.PIECE_NOT_FOUND));
+
+    if (!piece.getSaveStatus().equals(SaveStatus.APPLICATION)
+        || !piece.getProgressStatus().equals(ProgressStatus.WAITING)) {
+      throw new CustomException(PieceErrorCode.INVALID_APPLICATION);
+    }
+
+    piece.updateProgressStatus(ProgressStatus.UNREGISTERED);
+
+    return pieceId + "번 작품 등록을 거절했습니다.";
   }
 }

--- a/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingService.java
+++ b/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingService.java
@@ -1,5 +1,15 @@
-package com.likelion13.artium.global.ai.service;
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.global.ai.embedding.service;
 
-public interface AiService {
+public interface EmbeddingService {
 
+  /**
+   * 문자열 기반으로 임베딩하여 숫자 벡터로 생성해주는 메서드
+   *
+   * @param text 임베딩할 문자열
+   * @return 임베딩된 숫자 벡터 배열
+   */
+  public float[] embed(String text);
 }

--- a/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingService.java
+++ b/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingService.java
@@ -1,0 +1,5 @@
+package com.likelion13.artium.global.ai.service;
+
+public interface AiService {
+
+}

--- a/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingServiceImpl.java
@@ -1,0 +1,45 @@
+package com.likelion13.artium.global.ai.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.embedding.EmbeddingResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AiServiceImpl {
+    private final EmbeddingModel embeddingModel;
+
+    public float[] embed(String text) {
+        EmbeddingResponse resp = embeddingModel.embedForResponse(List.of(text));
+        return resp.getResults().get(0).getOutput();
+    }
+
+    public static float[] mean(List<float[]> vecs) {
+        if (vecs == null || vecs.isEmpty()) return null;
+        int d = vecs.get(0).length;
+        float[] sum = new float[d];
+        int n = 0;
+        for (float[] v : vecs) {
+            if (v == null || v.length != d) continue;
+            for (int i = 0; i < d; i++) sum[i] += v[i];
+            n++;
+        }
+        if (n == 0) return null;
+        for (int i = 0; i < d; i++) sum[i] /= n;
+        return sum;
+    }
+
+    public static float[] normalize(float[] v) {
+        if (v == null) return null;
+        double norm = 0;
+        for (float x : v) norm += x * x;
+        norm = Math.sqrt(norm);
+        if (norm == 0) return v;
+        float[] out = new float[v.length];
+        for (int i = 0; i < v.length; i++) out[i] = (float) (v[i] / norm);
+        return out;
+    }
+
+}

--- a/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/global/ai/embedding/service/EmbeddingServiceImpl.java
@@ -1,45 +1,25 @@
-package com.likelion13.artium.global.ai.service;
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.global.ai.embedding.service;
 
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+
 import org.springframework.ai.embedding.EmbeddingModel;
 import org.springframework.ai.embedding.EmbeddingResponse;
 import org.springframework.stereotype.Service;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
-public class AiServiceImpl {
-    private final EmbeddingModel embeddingModel;
+public class EmbeddingServiceImpl implements EmbeddingService {
 
-    public float[] embed(String text) {
-        EmbeddingResponse resp = embeddingModel.embedForResponse(List.of(text));
-        return resp.getResults().get(0).getOutput();
-    }
+  private final EmbeddingModel embeddingModel;
 
-    public static float[] mean(List<float[]> vecs) {
-        if (vecs == null || vecs.isEmpty()) return null;
-        int d = vecs.get(0).length;
-        float[] sum = new float[d];
-        int n = 0;
-        for (float[] v : vecs) {
-            if (v == null || v.length != d) continue;
-            for (int i = 0; i < d; i++) sum[i] += v[i];
-            n++;
-        }
-        if (n == 0) return null;
-        for (int i = 0; i < d; i++) sum[i] /= n;
-        return sum;
-    }
-
-    public static float[] normalize(float[] v) {
-        if (v == null) return null;
-        double norm = 0;
-        for (float x : v) norm += x * x;
-        norm = Math.sqrt(norm);
-        if (norm == 0) return v;
-        float[] out = new float[v.length];
-        for (int i = 0; i < v.length; i++) out[i] = (float) (v[i] / norm);
-        return out;
-    }
-
+  @Override
+  public float[] embed(String text) {
+    EmbeddingResponse resp = embeddingModel.embedForResponse(List.of(text));
+    return resp.getResults().get(0).getOutput();
+  }
 }

--- a/src/main/java/com/likelion13/artium/global/ai/vector/VectorUtils.java
+++ b/src/main/java/com/likelion13/artium/global/ai/vector/VectorUtils.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.global.ai.vector;
+
+public class VectorUtils {
+}

--- a/src/main/java/com/likelion13/artium/global/ai/vector/VectorUtils.java
+++ b/src/main/java/com/likelion13/artium/global/ai/vector/VectorUtils.java
@@ -1,4 +1,35 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.global.ai.vector;
 
+import java.util.List;
+
 public class VectorUtils {
+
+  public static float[] mean(List<float[]> vecs) {
+    if (vecs == null || vecs.isEmpty()) return null;
+    int d = vecs.get(0).length;
+    float[] sum = new float[d];
+    int n = 0;
+    for (float[] v : vecs) {
+      if (v == null || v.length != d) continue;
+      for (int i = 0; i < d; i++) sum[i] += v[i];
+      n++;
+    }
+    if (n == 0) return null;
+    for (int i = 0; i < d; i++) sum[i] /= n;
+    return sum;
+  }
+
+  public static float[] normalize(float[] v) {
+    if (v == null) return null;
+    double norm = 0;
+    for (float x : v) norm += x * x;
+    norm = Math.sqrt(norm);
+    if (norm == 0) return v;
+    float[] out = new float[v.length];
+    for (int i = 0; i < v.length; i++) out[i] = (float) (v[i] / norm);
+    return out;
+  }
 }

--- a/src/main/java/com/likelion13/artium/global/config/CorsConfig.java
+++ b/src/main/java/com/likelion13/artium/global/config/CorsConfig.java
@@ -33,6 +33,8 @@ public class CorsConfig {
     configuration.setExposedHeaders(List.of("Authorization"));
     // 쿠키나 인증 정보를 포함하는 요청 허용
     configuration.setAllowCredentials(true);
+    // 쿠키의 만료 시간을 3600초로 설정
+    configuration.setMaxAge(3600L);
     // 모든 경로에 대해 위의 CORS 설정을 적용
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
     source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/likelion13/artium/global/config/LLMConfig.java
+++ b/src/main/java/com/likelion13/artium/global/config/LLMConfig.java
@@ -1,4 +1,58 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.global.config;
 
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.document.MetadataMode;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.OpenAiEmbeddingModel;
+import org.springframework.ai.openai.OpenAiEmbeddingOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
 public class LLMConfig {
+
+  @Value("${spring.ai.openai.api-key}")
+  private String openaiApiKey;
+
+  @Bean
+  public OpenAiApi openAiApi() {
+    return OpenAiApi.builder().apiKey(openaiApiKey).build();
+  }
+
+  @Bean
+  public OpenAiChatOptions openAiChatOptions() {
+    return OpenAiChatOptions.builder()
+        .model("gpt-4o-mini")
+        .temperature(0.0)
+        .topP(1.0)
+        .maxCompletionTokens(1024)
+        .frequencyPenalty(0.0)
+        .presencePenalty(0.0)
+        .build();
+  }
+
+  @Bean
+  public OpenAiChatModel chatModel(OpenAiApi openAiApi, OpenAiChatOptions options) {
+    return OpenAiChatModel.builder().openAiApi(openAiApi).defaultOptions(options).build();
+  }
+
+  @Bean
+  public ChatClient chatClient(OpenAiChatModel chatModel) {
+    return ChatClient.create(chatModel);
+  }
+
+  @Bean
+  public EmbeddingModel embeddingModel(OpenAiApi openAiApi) {
+    return new OpenAiEmbeddingModel(
+        openAiApi,
+        MetadataMode.EMBED,
+        OpenAiEmbeddingOptions.builder().model("text-embedding-3-small").build());
+  }
 }

--- a/src/main/java/com/likelion13/artium/global/config/LLMConfig.java
+++ b/src/main/java/com/likelion13/artium/global/config/LLMConfig.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.global.config;
+
+public class LLMConfig {
+}

--- a/src/main/java/com/likelion13/artium/global/config/QdrantConfig.java
+++ b/src/main/java/com/likelion13/artium/global/config/QdrantConfig.java
@@ -1,0 +1,58 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
+package com.likelion13.artium.global.config;
+
+import java.time.Duration;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import reactor.netty.http.client.HttpClient;
+
+@Getter
+@Configuration
+public class QdrantWebClientConfig {
+
+  @Value("${qdrant.collection-name.piece}")
+  private String pieceCollection;
+
+  @Value("${qdrant.collection-name.exhibition}")
+  private String exhibitionCollection;
+
+  @Value("${qdrant.collection-name.user}")
+  private String userCollection;
+
+  @Value("${qdrant.vector-size}")
+  private int vectorSize;
+
+  @Value("${qdrant.distance:Cosine}")
+  private String distance;
+
+  @Bean
+  public WebClient qdrantWebClient(
+      @Value("${qdrant.base-url}") String baseUrl, @Value("${qdrant.api-key:}") String apiKey) {
+    HttpClient http = HttpClient.create().responseTimeout(Duration.ofSeconds(10)).compress(true);
+
+    WebClient.Builder b =
+        WebClient.builder()
+            .baseUrl(baseUrl)
+            .clientConnector(new ReactorClientHttpConnector(http))
+            .exchangeStrategies(
+                ExchangeStrategies.builder()
+                    .codecs(c -> c.defaultCodecs().maxInMemorySize(16 * 1024 * 1024))
+                    .build());
+
+    if (!apiKey.isBlank()) {
+      b.defaultHeader("api-key", apiKey);
+    }
+    b.defaultHeader("Accept", "application/json");
+
+    return b.build();
+  }
+}

--- a/src/main/java/com/likelion13/artium/global/config/QdrantConfig.java
+++ b/src/main/java/com/likelion13/artium/global/config/QdrantConfig.java
@@ -5,7 +5,6 @@ package com.likelion13.artium.global.config;
 
 import java.time.Duration;
 
-import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,11 +12,12 @@ import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import lombok.Getter;
 import reactor.netty.http.client.HttpClient;
 
 @Getter
 @Configuration
-public class QdrantWebClientConfig {
+public class QdrantConfig {
 
   @Value("${qdrant.collection-name.piece}")
   private String pieceCollection;

--- a/src/main/java/com/likelion13/artium/global/jwt/JwtProvider.java
+++ b/src/main/java/com/likelion13/artium/global/jwt/JwtProvider.java
@@ -347,7 +347,7 @@ public class JwtProvider {
     cookie.setHttpOnly(true);
     // cookie.setSecure(true);
     cookie.setPath("/");
-    cookie.setMaxAge((int) (maxAge / 1000));
+    cookie.setMaxAge((int) maxAge);
     response.addCookie(cookie);
 
     log.info("JWT 쿠키가 설정되었습니다 - 이름: {}, 만료: {}초", name, cookie.getMaxAge());

--- a/src/main/java/com/likelion13/artium/global/jwt/TokenRepository.java
+++ b/src/main/java/com/likelion13/artium/global/jwt/TokenRepository.java
@@ -98,6 +98,6 @@ public class TokenRepository {
    */
   public boolean isBlacklisted(String token) {
     String key = BLACKLIST_PREFIX + token;
-    return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    return redisTemplate.hasKey(key);
   }
 }

--- a/src/main/java/com/likelion13/artium/global/qdrant/entity/CollectionName.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/entity/CollectionName.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.global.qdrant.entity;
+
+public enum CollectionName {
+}

--- a/src/main/java/com/likelion13/artium/global/qdrant/entity/CollectionName.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/entity/CollectionName.java
@@ -1,4 +1,15 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.global.qdrant.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public enum CollectionName {
+  @Schema(description = "작품 컬렉션")
+  PIECE,
+  @Schema(description = "전시 컬렉션")
+  EXHIBITION,
+  @Schema(description = "사용자 컬렉션")
+  USER
 }

--- a/src/main/java/com/likelion13/artium/global/qdrant/exception/QdrantErrorCode.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/exception/QdrantErrorCode.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.global.qdrant.exception;
+
+public enum QdrantErrorCode {
+}

--- a/src/main/java/com/likelion13/artium/global/qdrant/exception/QdrantErrorCode.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/exception/QdrantErrorCode.java
@@ -1,4 +1,21 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.global.qdrant.exception;
 
-public enum QdrantErrorCode {
+import org.springframework.http.HttpStatus;
+
+import com.likelion13.artium.global.exception.model.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum QdrantErrorCode implements BaseErrorCode {
+  VECTOR_SIZE_MISMATCH("QDRANT_5001", "벡터의 크기가 알맞지 않습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+
+  private final String code;
+  private final String message;
+  private final HttpStatus status;
 }

--- a/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantService.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantService.java
@@ -1,4 +1,55 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.global.qdrant.service;
 
-public class QdrantService {
+import java.util.*;
+
+import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.global.qdrant.entity.CollectionName;
+
+public interface QdrantService {
+
+  /** 모든 컬렉션 생성 메서드 (해당 컬렉션이 없으면 생성, 있으면 통과) */
+  public void ensureAllCollections();
+
+  /**
+   * 컬렉션에 특정 객체의 벡터값을 기준으로 업서트 할 수 있는 유틸 함수(타 객체는 오버로딩 필요)
+   *
+   * @param id 식별자
+   * @param vector 작품의 원하는 값으로 임베딩 된 벡터값
+   * @param piece 작품 객체
+   * @param collectionName 업서트 할 위치(Qdrant의 컬렉션 명)
+   */
+  public void upsertPointUtil(Long id, float[] vector, Piece piece, CollectionName collectionName);
+
+  /**
+   * 포인트 모음(points)에 식별자, 벡터값, 페이로드를 기반으로 한 포인트를 하나 갱신(또는 삽입)
+   *
+   * @param id 식별자
+   * @param vector 벡터값
+   * @param payload 추가 속성 값들
+   * @param collectionName 포인트를 넣을 컬렉션 이름
+   */
+  public void upsertPoint(
+      Object id, float[] vector, Map<String, Object> payload, CollectionName collectionName);
+
+  /**
+   * 식별자 리스트를 받아 해당 식별자들의 벡터값 리스트를 반환
+   *
+   * @param ids 식별자 리스트
+   * @param collectionName 찾을 컬렉션 이름
+   * @return 벡터값 리스트 반환
+   */
+  public List<float[]> retrieveVectorsByIds(List<Long> ids, CollectionName collectionName);
+
+  /**
+   * @param query
+   * @param limit
+   * @param excludeArtworkIds
+   * @param collectionName
+   * @return
+   */
+  public List<Map<String, Object>> search(
+      float[] query, int limit, List<Long> excludeArtworkIds, CollectionName collectionName);
 }

--- a/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantService.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantService.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.global.qdrant.service;
+
+public class QdrantService {
+}

--- a/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantServiceImpl.java
@@ -1,4 +1,218 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.global.qdrant.service;
 
-public class QdrantServiceImpl {
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.global.config.QdrantConfig;
+import com.likelion13.artium.global.exception.CustomException;
+import com.likelion13.artium.global.qdrant.entity.CollectionName;
+import com.likelion13.artium.global.qdrant.exception.QdrantErrorCode;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QdrantServiceImpl implements QdrantService {
+
+  private final WebClient qdrantWebClient;
+  private final QdrantConfig qdrantConfig;
+
+  @PostConstruct
+  @Override
+  public void ensureAllCollections() {
+    for (CollectionName collectionName : CollectionName.values()) {
+      creatIfAbsent(collectionName);
+    }
+  }
+
+  @Override
+  public void upsertPointUtil(Long id, float[] vector, Piece piece, CollectionName collectionName) {
+    upsertPoint(
+        id,
+        vector,
+        Map.of(
+            "pieceId", piece.getId(),
+            "lang", "ko",
+            "createdAt", piece.getCreatedAt().toString()),
+        collectionName);
+  }
+
+  @Override
+  public void upsertPoint(
+      Object id, float[] vector, Map<String, Object> payload, CollectionName collectionName) {
+    if (vector.length != qdrantConfig.getVectorSize())
+      throw new CustomException(QdrantErrorCode.VECTOR_SIZE_MISMATCH);
+
+    Map<String, Object> point = new HashMap<>();
+    point.put("id", id);
+    point.put("vector", vector);
+    point.put("payload", payload);
+
+    Map<String, Object> body = Map.of("points", List.of(point));
+
+    qdrantWebClient
+        .put()
+        .uri("/collections/{name}/points?wait=true", getPrefix(collectionName))
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(body)
+        .retrieve()
+        .bodyToMono(String.class)
+        .block();
+  }
+
+  @Override
+  public List<float[]> retrieveVectorsByIds(List<Long> ids, CollectionName collectionName) {
+    if (ids.isEmpty()) return List.of();
+
+    Map<String, Object> body =
+        Map.of(
+            "ids", ids,
+            "with_vector", true,
+            "with_payload", false);
+
+    Map resp =
+        qdrantWebClient
+            .post()
+            .uri("/collections/{name}/points", getPrefix(collectionName))
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .retrieve()
+            .onStatus(
+                s -> s.is4xxClientError() || s.is5xxServerError(),
+                r ->
+                    r.bodyToMono(String.class)
+                        .map(
+                            msg ->
+                                new IllegalStateException(
+                                    "Qdrant retrieve failed: " + r.statusCode() + " - " + msg)))
+            .bodyToMono(Map.class)
+            .block();
+
+    List<Map<String, Object>> result = (List<Map<String, Object>>) resp.get("result");
+    List<float[]> out = new ArrayList<>();
+    for (Map<String, Object> p : result) {
+      List<Double> v = (List<Double>) p.get("vector");
+      float[] f = new float[v.size()];
+      for (int i = 0; i < v.size(); i++) f[i] = v.get(i).floatValue();
+      out.add(f);
+    }
+    return out;
+  }
+
+  @Override
+  public List<Map<String, Object>> search(
+      float[] query, int limit, List<Long> excludeIds, CollectionName collectionName) {
+    if (query.length != qdrantConfig.getVectorSize())
+      throw new IllegalArgumentException("Query size mismatch");
+
+    String objectId =
+        switch (collectionName) {
+          case PIECE -> "pieceId";
+          case EXHIBITION -> "exhibitionId";
+          case USER -> "userId";
+        };
+
+    List<Map<String, Object>> must = new ArrayList<>();
+    must.add(Map.of("key", "lang", "match", Map.of("value", "ko")));
+
+    List<Map<String, Object>> mustNot = new ArrayList<>();
+    for (Long id : excludeIds) {
+      mustNot.add(Map.of("key", objectId, "match", Map.of("value", id)));
+    }
+
+    Map<String, Object> filter = Map.of("must", must, "must_not", mustNot);
+
+    Map<String, Object> params = new HashMap<>();
+    params.put("exact", true);
+    params.put("hnsw_ef", 512);
+
+    Map<String, Object> body = new HashMap<>();
+    body.put("vector", query);
+    body.put("limit", limit);
+    body.put("with_payload", true);
+    body.put("params", params);
+    body.put("score_threshold", 0.30);
+    if (!must.isEmpty() || !mustNot.isEmpty()) body.put("filter", filter);
+
+    Map resp =
+        qdrantWebClient
+            .post()
+            .uri("/collections/{name}/points/search", getPrefix(collectionName))
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(body)
+            .retrieve()
+            .bodyToMono(Map.class)
+            .block();
+
+    return (List<Map<String, Object>>) resp.getOrDefault("result", List.of());
+  }
+
+  /**
+   * 컬렉션 이름을 통해서 qdrant에 해당 컬렉션을 생성(없으면 생성, 있으면 통과)
+   *
+   * @param collectionName 컬렉션 이름
+   */
+  private void creatIfAbsent(CollectionName collectionName) {
+
+    String collection = getPrefix(collectionName);
+
+    Boolean exists =
+        qdrantWebClient
+            .get()
+            .uri("/collections/{name}/exists", collection)
+            .retrieve()
+            .bodyToMono(Map.class)
+            .map(m -> ((Map<?, ?>) m.get("result")))
+            .map(r -> (Boolean) r.get("exists"))
+            .onErrorReturn(false)
+            .block();
+
+    if (Boolean.TRUE.equals(exists)) return;
+
+    Map<String, Object> body =
+        Map.of(
+            "vectors",
+            Map.of(
+                "size", qdrantConfig.getVectorSize(),
+                "distance", qdrantConfig.getDistance()));
+
+    qdrantWebClient
+        .put()
+        .uri("/collections/{name}", collection)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(body)
+        .retrieve()
+        .bodyToMono(String.class)
+        .onErrorResume(ex -> Mono.empty())
+        .block();
+  }
+
+  /**
+   * 컬렉션 이름을 통해 실제 지정된 컬렉션 값을 반환하는 메서드
+   *
+   * @param collectionName 컬렉션 이름
+   * @return 실제 지정된 컬렉션 값
+   */
+  private String getPrefix(CollectionName collectionName) {
+    return switch (collectionName) {
+      case PIECE -> qdrantConfig.getPieceCollection();
+      case EXHIBITION -> qdrantConfig.getExhibitionCollection();
+      case USER -> qdrantConfig.getUserCollection();
+    };
+  }
 }

--- a/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantServiceImpl.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.global.qdrant.service;
+
+public class QdrantServiceImpl {
+}


### PR DESCRIPTION
## ✨ 새로운 기능
- 어떤 기능을 추가했나요? : 좋아요 한 작품 리스트, 좋아요 기반 추천 작품 리스트 기능(+작품 승인, 거절)
- 사용자에게 어떤 이점을 주나요? : 좋아요 한 작품 리스트를 모아볼 수 있게 하고, 이를 기반으로 다른 작품을 추천해줌으로써 자신의 취향을 파악하고 다른 작품들 및 전시에 흥미를 느끼게하여 문화생활 활성화에 기여함

## 🛠 개발 상세
- 구현 방식 요약 : 작품 등록 승인 -> 해당 작품의 제목+내용이 임베딩되어 벡터값이 벡터DB에 저장 -> 좋아요를 기반으로 유사도가 높으며 자신의 작품이 아닌 다른 작품 리스트 추출 -> 사용자에게 추천
- 도입한 라이브러리 / 외부 API 여부 : open ai api

## 🧩 추가 고려사항
- [ ] 추가 데이터를 넣어가며 유사도 테스트 및 검증

## 🔗 관련 문서 / 이슈
- issue: #18 