### PR TITLE
:sparkles; Feat: 사용자 여러 정보 조회 기능 추가 (및 변경사항 적용 리팩토링)

### DIFF
--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserController.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserController.java
@@ -20,9 +20,11 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.CreatorResponse;
 import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.PreferenceResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserContactResponse;
 import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
 import com.likelion13.artium.domain.user.dto.response.UserSummaryResponse;
 import com.likelion13.artium.domain.user.entity.Age;
@@ -66,17 +68,32 @@ public interface UserController {
   @Operation(summary = "사용자 정보 조회", description = "현재 로그인된 사용자의 정보를 조회합니다.")
   ResponseEntity<BaseResponse<UserDetailResponse>> getUserDetail();
 
-  @GetMapping("/check")
+  @GetMapping("/check-code")
   @Operation(
-      summary = "닉네임 중복 여부 확인",
+      summary = "코드 중복 여부 확인",
       description =
           """
-              사용자가 입력한 닉네임이 이미 존재하는지 여부를 반환합니다.
-              true -> 중복되는 닉네임, 변경할 수 없음.
-              false -> 중복되지 않는 닉네임, 변경 가능.
+              사용자가 입력한 코드가 이미 존재하는지 여부를 반환합니다.
+              true -> 중복되는 코드, 변경할 수 없음.
+              false -> 중복되지 않는 코드, 변경 가능.
               """)
-  ResponseEntity<BaseResponse<Boolean>> checkNicknameDuplicated(
-      @Parameter(description = "확인할 닉네임", example = "아르티움") @RequestParam String nickname);
+  ResponseEntity<BaseResponse<Boolean>> checkCodeDuplicated(
+      @Parameter(description = "확인할 코드", example = "simonisnextdoor") @RequestParam String code);
+
+  @GetMapping("/{id}/profile")
+  @Operation(summary = "사용자 프로필 조회", description = "사용자의 프로필 사진, 닉네임을 조회합니다.")
+  ResponseEntity<BaseResponse<UserSummaryResponse>> getUserProfile(
+      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId);
+
+  @GetMapping("/{id}/contact")
+  @Operation(summary = "사용자 연락 수단 조회", description = "사용자의 이메일, 인스타그램을 조회합니다.")
+  ResponseEntity<BaseResponse<UserContactResponse>> getUserContact(
+      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId);
+
+  @GetMapping("/{id}/creator")
+  @Operation(summary = "크리에이터 정보 조회", description = "크리에이터의 정보를 조회합니다.")
+  ResponseEntity<BaseResponse<CreatorResponse>> getCreatorInfo(
+      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId);
 
   @GetMapping("/likes")
   @Operation(summary = "사용자가 좋아요 했던 크리에이터 목록을 조회")
@@ -88,9 +105,10 @@ public interface UserController {
   @Operation(summary = "사용자 맞춤 취향 설정 조회", description = "사용자 맞춤 취향 설정을 조회합니다.")
   ResponseEntity<BaseResponse<PreferenceResponse>> getPreferences();
 
-  @PutMapping("/nickname")
-  @Operation(summary = "닉네임 변경", description = "현재 로그인된 사용자의 닉네임을 변경합니다.")
-  ResponseEntity<BaseResponse<String>> updateNickname(
+  @PutMapping("/user-info")
+  @Operation(summary = "코드와 닉네임 변경", description = "현재 로그인된 사용자의 코드와 닉네임을 변경합니다.")
+  ResponseEntity<BaseResponse<String>> updateUserInfo(
+      @Parameter(description = "변경할 코드", example = "simonisnextdoor") @RequestParam String newCode,
       @Parameter(description = "변경할 닉네임", example = "아르티움") @RequestParam String newNickname);
 
   @PutMapping(value = "/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -120,12 +138,12 @@ public interface UserController {
   @Operation(summary = "[개발자]사용자 전체 조회", description = "스웨거를 사용해 전체 사용자를 조회합니다.")
   ResponseEntity<BaseResponse<List<UserDetailResponse>>> getAllUsers();
 
-  @PutMapping("/{piece-id}/approve")
+  @PutMapping("/{piece-id}/approve/admin")
   @Operation(summary = "[관리자]등록 신청한 작품 승인", description = "사용자가 등록 신청한 작품을 승인합니다.")
   ResponseEntity<BaseResponse<String>> approvePiece(
       @Parameter(description = "작품 식별자", example = "1") @PathVariable("piece-id") Long pieceId);
 
-  @PutMapping("/{piece-id}/reject")
+  @PutMapping("/{piece-id}/reject/admin")
   @Operation(summary = "[관리자]등록 신청한 작품 거절", description = "사용자가 등록 신청한 작품을 거절합니다.")
   ResponseEntity<BaseResponse<String>> rejectPiece(
       @Parameter(description = "작품 식별자", example = "1") @PathVariable("piece-id") Long pieceId);

--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
@@ -36,7 +36,6 @@ import com.likelion13.artium.global.page.exception.PageErrorStatus;
 import com.likelion13.artium.global.page.response.PageResponse;
 import com.likelion13.artium.global.response.BaseResponse;
 
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -88,21 +87,21 @@ public class UserControllerImpl implements UserController {
 
   @Override
   public ResponseEntity<BaseResponse<UserSummaryResponse>> getUserProfile(
-      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId) {
+      @PathVariable(value = "id") Long userId) {
     return ResponseEntity.status(200)
         .body(BaseResponse.success(userService.getUserProfile(userId)));
   }
 
   @Override
   public ResponseEntity<BaseResponse<UserContactResponse>> getUserContact(
-      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId) {
+      @PathVariable(value = "id") Long userId) {
     return ResponseEntity.status(200)
         .body(BaseResponse.success(userService.getUserContact(userId)));
   }
 
   @Override
   public ResponseEntity<BaseResponse<CreatorResponse>> getCreatorInfo(
-      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId) {
+      @PathVariable(value = "id") Long userId) {
     return ResponseEntity.status(200)
         .body(BaseResponse.success(userService.getCreatorInfo(userId)));
   }

--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
@@ -17,9 +17,11 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.CreatorResponse;
 import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.PreferenceResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserContactResponse;
 import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
 import com.likelion13.artium.domain.user.dto.response.UserSummaryResponse;
 import com.likelion13.artium.domain.user.entity.Age;
@@ -27,12 +29,14 @@ import com.likelion13.artium.domain.user.entity.FormatPreference;
 import com.likelion13.artium.domain.user.entity.Gender;
 import com.likelion13.artium.domain.user.entity.MoodPreference;
 import com.likelion13.artium.domain.user.entity.ThemePreference;
+import com.likelion13.artium.domain.user.exception.UserErrorCode;
 import com.likelion13.artium.domain.user.service.UserService;
 import com.likelion13.artium.global.exception.CustomException;
 import com.likelion13.artium.global.page.exception.PageErrorStatus;
 import com.likelion13.artium.global.page.response.PageResponse;
 import com.likelion13.artium.global.response.BaseResponse;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -65,9 +69,8 @@ public class UserControllerImpl implements UserController {
   }
 
   @Override
-  public ResponseEntity<BaseResponse<Boolean>> checkNicknameDuplicated(
-      @RequestParam String nickname) {
-    return ResponseEntity.ok(BaseResponse.success(userService.checkNicknameDuplicated(nickname)));
+  public ResponseEntity<BaseResponse<Boolean>> checkCodeDuplicated(@RequestParam String code) {
+    return ResponseEntity.ok(BaseResponse.success(userService.checkCodeDuplicated(code)));
   }
 
   @Override
@@ -84,8 +87,31 @@ public class UserControllerImpl implements UserController {
   }
 
   @Override
-  public ResponseEntity<BaseResponse<String>> updateNickname(@RequestParam String newNickname) {
-    return ResponseEntity.ok(BaseResponse.success(userService.updateNickname(newNickname)));
+  public ResponseEntity<BaseResponse<UserSummaryResponse>> getUserProfile(
+      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId) {
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(userService.getUserProfile(userId)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<UserContactResponse>> getUserContact(
+      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId) {
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(userService.getUserContact(userId)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<CreatorResponse>> getCreatorInfo(
+      @Parameter(description = "특정 유저 식별자") @PathVariable(value = "id") Long userId) {
+    return ResponseEntity.status(200)
+        .body(BaseResponse.success(userService.getCreatorInfo(userId)));
+  }
+
+  @Override
+  public ResponseEntity<BaseResponse<String>> updateUserInfo(
+      @RequestParam String newCode, @RequestParam String newNickname) {
+    return ResponseEntity.ok(
+        BaseResponse.success(userService.updateUserInfo(newCode, newNickname)));
   }
 
   @Override
@@ -102,6 +128,17 @@ public class UserControllerImpl implements UserController {
       @RequestParam List<ThemePreference> themePreferences,
       @RequestParam List<MoodPreference> moodPreferences,
       @RequestParam List<FormatPreference> formatPreferences) {
+    if (themePreferences == null
+        || themePreferences.isEmpty()
+        || themePreferences.size() > 5
+        || moodPreferences == null
+        || moodPreferences.isEmpty()
+        || moodPreferences.size() > 5
+        || formatPreferences == null
+        || formatPreferences.isEmpty()
+        || formatPreferences.size() > 5) {
+      throw new CustomException(UserErrorCode.INVALID_INPUT_REQUEST);
+    }
 
     return ResponseEntity.status(200)
         .body(

--- a/src/main/java/com/likelion13/artium/domain/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/request/SignUpRequest.java
@@ -33,4 +33,8 @@ public class SignUpRequest {
   @NotBlank(message = "사용자 닉네임 항목은 필수입니다.")
   @Schema(description = "사용자 닉네임", example = "아르티움")
   private String nickname;
+
+  @NotBlank(message = "사용자 코드 항목은 필수입니다. 중복될 수 없습니다.")
+  @Schema(description = "사용자 코드", example = "simonisnextdoor")
+  private String code;
 }

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/CreatorResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/CreatorResponse.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.domain.user.dto.response;
+
+public class UserResponse {
+}

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/CreatorResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/CreatorResponse.java
@@ -1,4 +1,34 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.domain.user.dto.response;
 
-public class UserResponse {
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "CreatorResponse DTO", description = "크리에이터 정보 응답 반환")
+public class CreatorResponse {
+
+  @Schema(description = "사용자 식별자", example = "1")
+  private Long userId;
+
+  @Schema(description = "닉네임", example = "김땡땡")
+  private String nickname;
+
+  @Schema(description = "코드", example = "simonisnextdoor")
+  private String code;
+
+  @Schema(
+      description = "프로필 이미지 URL",
+      example = "http://k.kakaocdn.net/dn/oOPCG/btsPjlOHjk6/6jx0PyBKkHHyCfbV8IY741/img_640x640.jpg")
+  private String profileImageUrl;
+
+  @Schema(description = "사용자 소개", example = "안녕하세요. 아름다운 바다를 좋아하는")
+  private String introduction;
+
+  @Schema(description = "요청 사용자의 좋아요 여부", example = "false")
+  private Boolean isLike;
 }

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/LikeResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/LikeResponse.java
@@ -12,9 +12,9 @@ import lombok.Getter;
 @Schema(title = "LikeResponse DTO", description = "사용자 좋아요 요청에 대한 응답 반환")
 public class LikeResponse {
 
-  @Schema(description = "좋아요를 보낸 사용자 닉네임", example = "윤희준")
-  private String currentUserNickname;
+  @Schema(description = "좋아요를 보낸 사용자 코드", example = "heejun0109")
+  private String currentUserCode;
 
-  @Schema(description = "좋아요를 받은 사용자 닉네임", example = "금시언")
-  private String targetUserNickname;
+  @Schema(description = "좋아요를 받은 사용자 코드", example = "simonisnextdoor")
+  private String targetUserCode;
 }

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/UserContactResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/UserContactResponse.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.domain.user.dto.response;
+
+public class UserContactResponse {
+}

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/UserContactResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/UserContactResponse.java
@@ -1,4 +1,23 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.domain.user.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "UserContactResponse", description = "사용자 연락 수단 응답 반환")
 public class UserContactResponse {
+
+  @Schema(description = "사용자 식별자", example = "1")
+  private Long userId;
+
+  @Schema(description = "사용자 이메일", example = "example@gmail.com")
+  private String email;
+
+  @Schema(description = "사용자 인스타그램", example = "simonisnextdoor")
+  private String instagram;
 }

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/UserDetailResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/UserDetailResponse.java
@@ -23,6 +23,9 @@ public class UserDetailResponse {
   @Schema(description = "닉네임", example = "나나나난")
   private String nickname;
 
+  @Schema(description = "코드", example = "simonisnextdoor")
+  private String code;
+
   @Schema(
       description = "프로필 이미지 URL",
       example = "http://k.kakaocdn.net/dn/oOPCG/btsPjlOHjk6/6jx0PyBKkHHyCfbV8IY741/img_640x640.jpg")

--- a/src/main/java/com/likelion13/artium/domain/user/dto/response/UserSummaryResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/user/dto/response/UserSummaryResponse.java
@@ -18,6 +18,9 @@ public class UserSummaryResponse {
   @Schema(description = "닉네임", example = "김땡땡")
   private String nickname;
 
+  @Schema(description = "코드", example = "simonisnextdoor")
+  private String code;
+
   @Schema(
       description = "프로필 이미지 URL",
       example = "http://k.kakaocdn.net/dn/oOPCG/btsPjlOHjk6/6jx0PyBKkHHyCfbV8IY741/img_640x640.jpg")

--- a/src/main/java/com/likelion13/artium/domain/user/entity/Role.java
+++ b/src/main/java/com/likelion13/artium/domain/user/entity/Role.java
@@ -7,9 +7,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public enum Role {
   @Schema(description = "사용자")
-  USER,
+  ROLE_USER,
   @Schema(description = "관리자")
-  ADMIN,
+  ROLE_ADMIN,
   @Schema(description = "개발자")
-  DEVELOPER;
+  ROLE_DEVELOPER;
 }

--- a/src/main/java/com/likelion13/artium/domain/user/entity/User.java
+++ b/src/main/java/com/likelion13/artium/domain/user/entity/User.java
@@ -57,8 +57,11 @@ public class User extends BaseTimeEntity {
   @Column(name = "password")
   private String password;
 
-  @Column(name = "nickname", nullable = false, unique = true)
+  @Column(name = "nickname", nullable = false)
   private String nickname;
+
+  @Column(name = "code", unique = true)
+  private String code;
 
   @Column(name = "gender")
   @Enumerated(EnumType.STRING)
@@ -101,7 +104,7 @@ public class User extends BaseTimeEntity {
   @Column(name = "role", nullable = false)
   @Enumerated(EnumType.STRING)
   @Builder.Default
-  private Role role = Role.USER;
+  private Role role = Role.ROLE_USER;
 
   @Column(name = "is_deleted", nullable = false)
   @Builder.Default
@@ -146,11 +149,12 @@ public class User extends BaseTimeEntity {
         .password(UUID.randomUUID().toString())
         .nickname(nickname)
         .profileImageUrl(profileImageUrl)
-        .role(Role.USER)
+        .role(Role.ROLE_USER)
         .build();
   }
 
-  public void updateNickname(String newNickname) {
+  public void updateUserInfo(String newCode, String newNickname) {
+    this.code = newCode;
     this.nickname = newNickname;
   }
 

--- a/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
@@ -14,12 +14,14 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
   USERNAME_ALREADY_EXISTS("USER_4001", "이미 존재하는 사용자 아이디입니다.", HttpStatus.BAD_REQUEST),
-  NICKNAME_ALREADY_EXISTS("USER_4002", "이미 존재하는 사용자 닉네임입니다.", HttpStatus.BAD_REQUEST),
+  CODE_ALREADY_EXISTS("USER_4002", "이미 존재하는 사용자 닉네임입니다.", HttpStatus.BAD_REQUEST),
   USER_NOT_FOUND("USER_4003", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   UNAUTHORIZED("USER_4004", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
   CANNOT_LIKE_SELF("USER_4005", "자기 자신은 좋아요 할 수 없습니다.", HttpStatus.BAD_REQUEST),
   ALREADY_LIKED("USER_4006", "이미 좋아요한 사용자입니다.", HttpStatus.BAD_REQUEST),
   LIKE_NOT_FOUND("USER_4007", "좋아요 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  INVALID_INPUT_REQUEST("USER_4008", "유효하지 입력 값을 포함한 요청입니다.", HttpStatus.BAD_REQUEST),
+  FORBIDDEN("USER_4009", "허가되지 않은 접근입니다.", HttpStatus.FORBIDDEN),
   ;
 
   private final String code;

--- a/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/likelion13/artium/domain/user/exception/UserErrorCode.java
@@ -14,13 +14,13 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
   USERNAME_ALREADY_EXISTS("USER_4001", "이미 존재하는 사용자 아이디입니다.", HttpStatus.BAD_REQUEST),
-  CODE_ALREADY_EXISTS("USER_4002", "이미 존재하는 사용자 닉네임입니다.", HttpStatus.BAD_REQUEST),
+  CODE_ALREADY_EXISTS("USER_4002", "이미 존재하는 사용자 코드입니다.", HttpStatus.BAD_REQUEST),
   USER_NOT_FOUND("USER_4003", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   UNAUTHORIZED("USER_4004", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
   CANNOT_LIKE_SELF("USER_4005", "자기 자신은 좋아요 할 수 없습니다.", HttpStatus.BAD_REQUEST),
   ALREADY_LIKED("USER_4006", "이미 좋아요한 사용자입니다.", HttpStatus.BAD_REQUEST),
   LIKE_NOT_FOUND("USER_4007", "좋아요 내역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-  INVALID_INPUT_REQUEST("USER_4008", "유효하지 입력 값을 포함한 요청입니다.", HttpStatus.BAD_REQUEST),
+  INVALID_INPUT_REQUEST("USER_4008", "유효하지 않은 입력 값을 포함한 요청입니다.", HttpStatus.BAD_REQUEST),
   FORBIDDEN("USER_4009", "허가되지 않은 접근입니다.", HttpStatus.FORBIDDEN),
   ;
 

--- a/src/main/java/com/likelion13/artium/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/user/mapper/UserMapper.java
@@ -10,9 +10,11 @@ import org.springframework.stereotype.Component;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionLike;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionParticipant;
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.CreatorResponse;
 import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.PreferenceResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserContactResponse;
 import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
 import com.likelion13.artium.domain.user.dto.response.UserSummaryResponse;
 import com.likelion13.artium.domain.user.entity.FormatPreference;
@@ -29,8 +31,9 @@ public class UserMapper {
         .username(request.getUsername())
         .password(encodedPassword)
         .nickname(request.getNickname())
+        .code(request.getCode())
         .profileImageUrl(imageUrl)
-        .role(Role.USER)
+        .role(Role.ROLE_USER)
         .isDeleted(false)
         .build();
   }
@@ -39,10 +42,10 @@ public class UserMapper {
     return SignUpResponse.builder().userId(user.getId()).username(user.getUsername()).build();
   }
 
-  public LikeResponse toLikeResponse(String currentUser, String targetUser) {
+  public LikeResponse toLikeResponse(String currentUserCode, String targetUserCode) {
     return LikeResponse.builder()
-        .currentUserNickname(currentUser)
-        .targetUserNickname(targetUser)
+        .currentUserCode(currentUserCode)
+        .targetUserCode(targetUserCode)
         .build();
   }
 
@@ -51,6 +54,7 @@ public class UserMapper {
         .userId(user.getId())
         .username(user.getUsername())
         .nickname(user.getNickname())
+        .code(user.getCode())
         .profileImageUrl(user.getProfileImageUrl())
         .exhibitionParticipantIds(
             user.getExhibitionParticipants().stream()
@@ -75,7 +79,27 @@ public class UserMapper {
     return UserSummaryResponse.builder()
         .userId(user.getId())
         .nickname(user.getNickname())
+        .code(user.getCode())
         .profileImageUrl(user.getProfileImageUrl())
+        .build();
+  }
+
+  public UserContactResponse toUserContactResponse(User user) {
+    return UserContactResponse.builder()
+        .userId(user.getId())
+        .email(user.getEmail())
+        .instagram(user.getInstagram())
+        .build();
+  }
+
+  public CreatorResponse toCreatorResponse(User user, Boolean isLike) {
+    return CreatorResponse.builder()
+        .userId(user.getId())
+        .nickname(user.getNickname())
+        .code(user.getCode())
+        .profileImageUrl(user.getProfileImageUrl())
+        .introduction(user.getIntroduction())
+        .isLike(isLike)
         .build();
   }
 

--- a/src/main/java/com/likelion13/artium/domain/user/mapper/UserMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/user/mapper/UserMapper.java
@@ -47,8 +47,8 @@ public class UserMapper {
     return SignUpResponse.builder().userId(user.getId()).username(user.getUsername()).build();
   }
 
-  public LikeResponse toLikeResponse(String currentUserCode, String targetUserCode) {
-    return LikeResponse.builder()
+  public UserLikeResponse toUserLikeResponse(String currentUserCode, String targetUserCode) {
+    return UserLikeResponse.builder()
         .currentUserCode(currentUserCode)
         .targetUserCode(targetUserCode)
         .build();

--- a/src/main/java/com/likelion13/artium/domain/user/repository/UserLikeRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/user/repository/UserLikeRepository.java
@@ -17,4 +17,7 @@ public interface UserLikeRepository extends JpaRepository<UserLike, Long> {
   @Query(
       "select ul.liked " + "from UserLike ul " + "where ul.liker.id = :likerId order by ul.id desc")
   Page<User> findLikedUserByLikerId(@Param("likerId") Long likerId, Pageable pageable);
+
+  Boolean existsByLiker_IdAndLiked_Id(
+      @Param("likerId") Long likerId, @Param("likedId") Long likedId);
 }

--- a/src/main/java/com/likelion13/artium/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/user/repository/UserRepository.java
@@ -20,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByNickname(String nickname);
 
   boolean existsByCode(String code);
+
+  boolean existsByCodeAndIdNot(String code, Long id);
 }

--- a/src/main/java/com/likelion13/artium/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/user/repository/UserRepository.java
@@ -18,4 +18,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   boolean existsByUsername(String username);
 
   boolean existsByNickname(String nickname);
+
+  boolean existsByCode(String code);
 }

--- a/src/main/java/com/likelion13/artium/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion13/artium/domain/user/service/UserService.java
@@ -9,9 +9,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.likelion13.artium.domain.user.dto.request.SignUpRequest;
+import com.likelion13.artium.domain.user.dto.response.CreatorResponse;
 import com.likelion13.artium.domain.user.dto.response.LikeResponse;
 import com.likelion13.artium.domain.user.dto.response.PreferenceResponse;
 import com.likelion13.artium.domain.user.dto.response.SignUpResponse;
+import com.likelion13.artium.domain.user.dto.response.UserContactResponse;
 import com.likelion13.artium.domain.user.dto.response.UserDetailResponse;
 import com.likelion13.artium.domain.user.dto.response.UserSummaryResponse;
 import com.likelion13.artium.domain.user.entity.Age;
@@ -73,21 +75,22 @@ public interface UserService {
   UserDetailResponse getUserDetail();
 
   /**
-   * 닉네임 사용 가능 여부를 확인합니다.
+   * 코드 사용 가능 여부를 확인합니다.
    *
-   * @param nickname 확인할 닉네임 문자열
-   * @return true이면 사용 가능, false면 중복
+   * @param code 확인할 코드 문자열
+   * @return true이면 중복, false면 사용 가능
    */
-  Boolean checkNicknameDuplicated(String nickname);
+  Boolean checkCodeDuplicated(String code);
 
   /**
    * 사용자의 닉네임을 변경합니다.
    *
+   * @param newCode 변경할 새로운 코드
    * @param newNickname 변경할 새로운 닉네임
    * @return 변경 완료 메시지 문자열
    * @throws CustomException 닉네임 중복 등 변경 불가 시 발생
    */
-  String updateNickname(String newNickname);
+  String updateUserInfo(String newCode, String newNickname);
 
   /**
    * 사용자의 프로필 이미지를 변경합니다.
@@ -167,4 +170,28 @@ public interface UserService {
    * @return 좋아요 한 크리에이터 페이지 응답값
    */
   PageResponse<UserSummaryResponse> getLikes(Pageable pageable);
+
+  /**
+   * 사용자의 닉네임, 프로필 사진을 반환
+   *
+   * @param userId 찾을 사용자 식별자
+   * @return 사용자 정보 응답 객체
+   */
+  UserSummaryResponse getUserProfile(Long userId);
+
+  /**
+   * 사용자의 이메일, 인스타를 반환
+   *
+   * @param userId 찾을 사용자 식별자
+   * @return 사용자 정보 응답 객체
+   */
+  UserContactResponse getUserContact(Long userId);
+
+  /**
+   * 크리에이터의 정보를 반환
+   *
+   * @param userId 찾을 사용자 식별자
+   * @return 크리에이터 정보 응답 객체
+   */
+  CreatorResponse getCreatorInfo(Long userId);
 }

--- a/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
@@ -127,10 +127,10 @@ public class UserServiceImpl implements UserService {
       }
       throw e;
     }
-      log.info(
-          "새로운 사용자 좋아요 생성 - 좋아요를 보낸 사용자: {}, 좋아요를 받은 사용자: {}",
-          currentUser.getNickname(),
-          targetUser.getNickname());
+    log.info(
+        "새로운 사용자 좋아요 생성 - 좋아요를 보낸 사용자: {}, 좋아요를 받은 사용자: {}",
+        currentUser.getNickname(),
+        targetUser.getNickname());
     return userMapper.toUserLikeResponse(currentUser.getCode(), targetUser.getCode());
   }
 

--- a/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
@@ -131,7 +131,7 @@ public class UserServiceImpl implements UserService {
           "새로운 사용자 좋아요 생성 - 좋아요를 보낸 사용자: {}, 좋아요를 받은 사용자: {}",
           currentUser.getNickname(),
           targetUser.getNickname());
-    return userMapper.toLikeResponse(currentUser.getCode(), targetUser.getCode());
+    return userMapper.toUserLikeResponse(currentUser.getCode(), targetUser.getCode());
   }
 
   @Override
@@ -287,7 +287,7 @@ public class UserServiceImpl implements UserService {
     user.getLikedUsers().remove(userLike);
     targetUser.getLikedByUsers().remove(userLike);
 
-    return userMapper.toUserLikeResponse(user.getNickname(), targetUser.getNickname());
+    return userMapper.toUserLikeResponse(user.getCode(), targetUser.getCode());
   }
 
   @Override

--- a/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/service/UserServiceImpl.java
@@ -206,17 +206,14 @@ public class UserServiceImpl implements UserService {
   public String updateUserInfo(String newCode, String newNickname) {
     User user = getCurrentUser();
 
-    if (userRepository.existsByCode(newCode)) {
+    if (newCode != null && userRepository.existsByCodeAndIdNot(newCode, user.getId())) {
       log.error("코드 중복 시도 - userId: {}, code: {}", user.getId(), newCode);
       throw new CustomException(UserErrorCode.CODE_ALREADY_EXISTS);
     }
 
     user.updateUserInfo(newCode, newNickname);
     log.info(
-        "사용자 닉네임 변경 - userId: {}, newCode: {}, newNickname: {}",
-        user.getId(),
-        newCode,
-        newNickname);
+        "사용자 정보 변경 - userId: {}, newCode: {}, newNickname: {}", user.getId(), newCode, newNickname);
 
     return "newCode: " + newCode + ", newNickname: " + newNickname;
   }


### PR DESCRIPTION
## ✨ 새로운 기능
- 어떤 기능을 추가했나요? : 사용자의 여러 정보 조회 기능 추가 (+변경 사항을 적용한 추가 리팩토링)
- 사용자에게 어떤 이점을 주나요? : 다른 사용자의 정보를 조회할 수 있게함

## 🛠 개발 상세
- 구현 방식 요약 : 도메인형 계층형 아키텍처 구조 방식을 활용하여 기능 개발

## 🔗 관련 문서 / 이슈
- issue: #31 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 사용자 프로필·연락처·크리에이터 정보 조회 API 추가
  * 회원가입 및 사용자 응답에 코드(code) 필드 도입
  * 좋아요 응답이 닉네임 대신 코드 제공
  * 크리에이터/연락처 응답 DTO 추가

* 리팩터링
  * 닉네임 중복 검사 → 코드 중복 검사로 변경, 경로 /check → /check-code
  * 닉네임 수정 → 사용자 정보 수정(newCode, newNickname)으로 통합
  * 관리자 작품 승인/반려 엔드포인트에 /admin 접미사 적용
  * 권한 상수 명확화(ROLE_USER/ROLE_ADMIN/ROLE_DEVELOPER)
  * 선호설정 입력값 유효성 검증 강화(빈 값 방지, 최대 5개)
  * 저장소에 코드 기반 존재 검사 메서드 추가 (existsByCode 등)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->