### PR TITLE
:sparkles: Feat: 관심사 기반 작품 추천 기능 추가 및 보완

### DIFF
--- a/src/main/java/com/likelion13/artium/domain/exhibition/dto/response/ExhibitionSummaryResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/dto/response/ExhibitionSummaryResponse.java
@@ -1,4 +1,23 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.domain.exhibition.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "ExhibitionSummaryResponse DTO", description = "전시 정보 요약 응답 반환")
 public class ExhibitionSummaryResponse {
+
+  @Schema(description = "전시 식별자", example = "1")
+  private Long exhibitionId;
+
+  @Schema(description = "썸네일 사진 URL", example = "")
+  private String thumbnailImageUrl;
+
+  @Schema(description = "전시 제목", example = "성북구 신인 작가 합동 전시: 두 번째 여름")
+  private String title;
 }

--- a/src/main/java/com/likelion13/artium/domain/exhibition/dto/response/ExhibitionSummaryResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/dto/response/ExhibitionSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.domain.exhibition.dto.response;
+
+public class ExhibitionSummaryResponse {
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/entity/Exhibition.java
@@ -23,7 +23,7 @@ import jakarta.persistence.Table;
 
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionLike;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionParticipant;
-import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionPiece;
 import com.likelion13.artium.domain.review.entity.Review;
 import com.likelion13.artium.domain.user.entity.User;
 import com.likelion13.artium.global.common.BaseTimeEntity;
@@ -97,7 +97,7 @@ public class Exhibition extends BaseTimeEntity {
 
   @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default
-  private List<Piece> pieces = new ArrayList<>();
+  private List<ExhibitionPiece> exhibitionPieces = new ArrayList<>();
 
   @OneToMany(mappedBy = "exhibition", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default

--- a/src/main/java/com/likelion13/artium/domain/exhibition/mapper/ExhibitionMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/mapper/ExhibitionMapper.java
@@ -11,10 +11,12 @@ import com.likelion13.artium.domain.exhibition.dto.request.ExhibitionRequest;
 import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionDetailResponse;
 import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionLikeResponse;
 import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionResponse;
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionSummaryResponse;
 import com.likelion13.artium.domain.exhibition.entity.Exhibition;
 import com.likelion13.artium.domain.exhibition.entity.ExhibitionStatus;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionLike;
 import com.likelion13.artium.domain.exhibition.mapping.ExhibitionParticipant;
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionPiece;
 import com.likelion13.artium.domain.user.entity.User;
 
 @Component
@@ -25,6 +27,7 @@ public class ExhibitionMapper {
       ExhibitionRequest request,
       ExhibitionStatus status,
       User user,
+      List<ExhibitionPiece> exhibitionPieceList,
       List<ExhibitionParticipant> exhibitionParticipantList) {
     return Exhibition.builder()
         .thumbnailImageUrl(imageUrl)
@@ -39,6 +42,7 @@ public class ExhibitionMapper {
         .exhibitionStatus(status)
         .fillAll(validateExhibitionFields(imageUrl, request, status))
         .user(user)
+        .exhibitionPieces(exhibitionPieceList)
         .exhibitionParticipants(exhibitionParticipantList)
         .build();
   }
@@ -56,6 +60,14 @@ public class ExhibitionMapper {
         .startDate(exhibition.getStartDate())
         .endDate(exhibition.getEndDate())
         .address(exhibition.getAddress())
+        .build();
+  }
+
+  public ExhibitionSummaryResponse toExhibitionSummaryResponse(Exhibition exhibition) {
+    return ExhibitionSummaryResponse.builder()
+        .exhibitionId(exhibition.getId())
+        .thumbnailImageUrl(exhibition.getThumbnailImageUrl())
+        .title(exhibition.getTitle())
         .build();
   }
 

--- a/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionPiece.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionPiece.java
@@ -8,14 +8,16 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import com.likelion13.artium.domain.exhibition.entity.Exhibition;
 import com.likelion13.artium.domain.piece.entity.Piece;
 import com.likelion13.artium.global.common.BaseTimeEntity;
 
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,7 +30,17 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Tag(name = "exhibition_piece")
+@Table(
+    name = "exhibition_piece",
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uq_exhibition_piece_exhibition_piece",
+          columnNames = {"exhibition_id", "piece_id"})
+    },
+    indexes = {
+      @Index(name = "idx_exhibition_piece_exhibition_id", columnList = "exhibition_id"),
+      @Index(name = "idx_exhibition_piece_piece_id", columnList = "piece_id")
+    })
 public class ExhibitionPiece extends BaseTimeEntity {
 
   @Id

--- a/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionPiece.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionPiece.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.domain.exhibition.mapping;
+
+public class ExhibitionPiece {
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionPiece.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/mapping/ExhibitionPiece.java
@@ -1,4 +1,46 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.domain.exhibition.mapping;
 
-public class ExhibitionPiece {
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.piece.entity.Piece;
+import com.likelion13.artium.global.common.BaseTimeEntity;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Tag(name = "exhibition_piece")
+public class ExhibitionPiece extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Setter
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "exhibition_id", nullable = false)
+  private Exhibition exhibition;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "piece_id", nullable = false)
+  private Piece piece;
 }

--- a/src/main/java/com/likelion13/artium/domain/exhibition/repository/ExhibitionPieceRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/repository/ExhibitionPieceRepository.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.domain.exhibition.repository;
+
+public interface ExhibitionPieceRepository {
+}

--- a/src/main/java/com/likelion13/artium/domain/exhibition/repository/ExhibitionPieceRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/exhibition/repository/ExhibitionPieceRepository.java
@@ -1,4 +1,10 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.domain.exhibition.repository;
 
-public interface ExhibitionPieceRepository {
-}
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionPiece;
+
+public interface ExhibitionPieceRepository extends JpaRepository<ExhibitionPiece, Long> {}

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceController.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceController.java
@@ -23,6 +23,7 @@ import com.likelion13.artium.domain.piece.dto.request.UpdatePieceRequest;
 import com.likelion13.artium.domain.piece.dto.response.PieceFeedResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceSummaryResponse;
+import com.likelion13.artium.domain.piece.entity.RecommendSortBy;
 import com.likelion13.artium.domain.piece.entity.SaveStatus;
 import com.likelion13.artium.domain.pieceLike.dto.response.PieceLikeResponse;
 import com.likelion13.artium.global.page.response.PageResponse;
@@ -58,7 +59,7 @@ public interface PieceController {
       description = "피드의 작품 리스트 중 인기순, 최신순에 해당하는 리스트 조회 API")
   @GetMapping
   ResponseEntity<BaseResponse<PageResponse<PieceFeedResponse>>> getPiecePageByType(
-      @Parameter(description = "정렬 기준", example = "HOTTEST") @RequestParam SortBy sortBy,
+      @Parameter(description = "분류 기준", example = "HOTTEST") @RequestParam SortBy sortBy,
       @Parameter(description = "페이지 번호", example = "1") @RequestParam Integer pageNum,
       @Parameter(description = "페이지 크기", example = "3") @RequestParam Integer pageSize);
 
@@ -86,7 +87,8 @@ public interface PieceController {
       summary = "취향 기반 추천 작품 리스트 조회",
       description = "사용자가 좋아요 한 작품을 기반으로 추천 작품 리스트를 조회하기 위한 API")
   @GetMapping("/recommendations")
-  ResponseEntity<BaseResponse<PageResponse<PieceSummaryResponse>>> getRecommendationPieces(
+  ResponseEntity<BaseResponse<PageResponse<PieceFeedResponse>>> getRecommendationPieces(
+      @Parameter(description = "분류 기준", example = "FAVORITE") @RequestParam RecommendSortBy sortBy,
       @Parameter(description = "페이지 번호", example = "1") @RequestParam Integer pageNum,
       @Parameter(description = "페이지 크기", example = "3") @RequestParam Integer pageSize);
 

--- a/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/controller/PieceControllerImpl.java
@@ -21,6 +21,7 @@ import com.likelion13.artium.domain.piece.dto.request.UpdatePieceRequest;
 import com.likelion13.artium.domain.piece.dto.response.PieceFeedResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceSummaryResponse;
+import com.likelion13.artium.domain.piece.entity.RecommendSortBy;
 import com.likelion13.artium.domain.piece.entity.SaveStatus;
 import com.likelion13.artium.domain.piece.exception.PieceErrorCode;
 import com.likelion13.artium.domain.piece.service.PieceService;
@@ -112,12 +113,14 @@ public class PieceControllerImpl implements PieceController {
   }
 
   @Override
-  public ResponseEntity<BaseResponse<PageResponse<PieceSummaryResponse>>> getRecommendationPieces(
-      @RequestParam Integer pageNum, @RequestParam Integer pageSize) {
+  public ResponseEntity<BaseResponse<PageResponse<PieceFeedResponse>>> getRecommendationPieces(
+      @RequestParam RecommendSortBy sortBy,
+      @RequestParam Integer pageNum,
+      @RequestParam Integer pageSize) {
     Pageable pageable = validatePageable(pageNum, pageSize);
 
     return ResponseEntity.status(HttpStatus.OK)
-        .body(BaseResponse.success(pieceService.getRecommendationPiecePage(pageable)));
+        .body(BaseResponse.success(pieceService.getRecommendationPiecePage(sortBy, pageable)));
   }
 
   @Override

--- a/src/main/java/com/likelion13/artium/domain/piece/dto/response/PieceResponse.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/dto/response/PieceResponse.java
@@ -5,6 +5,7 @@ package com.likelion13.artium.domain.piece.dto.response;
 
 import java.util.List;
 
+import com.likelion13.artium.domain.exhibition.dto.response.ExhibitionSummaryResponse;
 import com.likelion13.artium.domain.piece.entity.ProgressStatus;
 import com.likelion13.artium.domain.piece.entity.SaveStatus;
 import com.likelion13.artium.domain.pieceDetail.dto.response.PieceDetailSummaryResponse;
@@ -44,6 +45,9 @@ public class PieceResponse {
 
   @Schema(description = "디테일 컷 리스트")
   private List<PieceDetailSummaryResponse> pieceDetails;
+
+  @Schema(description = "전시 중일 때의 전시 정보 리스트")
+  private List<ExhibitionSummaryResponse> exhibitions;
 
   @Schema(description = "요청 사용자의 좋아요 여부", example = "false")
   @Builder.Default

--- a/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/entity/Piece.java
@@ -20,7 +20,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 
-import com.likelion13.artium.domain.exhibition.entity.Exhibition;
+import com.likelion13.artium.domain.exhibition.mapping.ExhibitionPiece;
 import com.likelion13.artium.domain.pieceDetail.entity.PieceDetail;
 import com.likelion13.artium.domain.pieceLike.entity.PieceLike;
 import com.likelion13.artium.domain.user.entity.User;
@@ -70,9 +70,9 @@ public class Piece extends BaseTimeEntity {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "exhibition_id")
-  private Exhibition exhibition;
+  @OneToMany(mappedBy = "piece", cascade = CascadeType.ALL, orphanRemoval = true)
+  @Builder.Default
+  private List<ExhibitionPiece> exhibitionPieces = new ArrayList<>();
 
   @OneToMany(mappedBy = "piece", cascade = CascadeType.ALL, orphanRemoval = true)
   @Builder.Default

--- a/src/main/java/com/likelion13/artium/domain/piece/entity/RecommendSortBy.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/entity/RecommendSortBy.java
@@ -1,4 +1,13 @@
+/* 
+ * Copyright (c) LikeLion13th Problem not Found 
+ */
 package com.likelion13.artium.domain.piece.entity;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public enum RecommendSortBy {
+  @Schema(description = "내 취향 저격 리스트")
+  FAVORITE,
+  @Schema(description = "색다른 도전 리스트")
+  NEW_STYLE
 }

--- a/src/main/java/com/likelion13/artium/domain/piece/entity/RecommendSortBy.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/entity/RecommendSortBy.java
@@ -1,0 +1,4 @@
+package com.likelion13.artium.domain.piece.entity;
+
+public enum RecommendSortBy {
+}

--- a/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/mapper/PieceMapper.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
+import com.likelion13.artium.domain.exhibition.mapper.ExhibitionMapper;
 import com.likelion13.artium.domain.piece.dto.response.PieceFeedResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceSummaryResponse;
@@ -20,6 +21,7 @@ import lombok.RequiredArgsConstructor;
 public class PieceMapper {
 
   private final PieceDetailMapper pieceDetailMapper;
+  private final ExhibitionMapper exhibitionMapper;
 
   public PieceResponse toPieceResponse(Piece piece) {
     return toPieceResponseWithLike(piece, null);
@@ -44,6 +46,15 @@ public class PieceMapper {
                 ? List.of()
                 : piece.getPieceDetails().stream()
                     .map(pieceDetailMapper::toPieceDetailSummaryResponse)
+                    .toList())
+        .exhibitions(
+            piece.getExhibitionPieces() == null
+                ? List.of()
+                : piece.getExhibitionPieces().stream()
+                    .map(
+                        exhibitionPiece ->
+                            exhibitionMapper.toExhibitionSummaryResponse(
+                                exhibitionPiece.getExhibition()))
                     .toList());
   }
 

--- a/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/repository/PieceRepository.java
@@ -19,6 +19,17 @@ public interface PieceRepository extends JpaRepository<Piece, Long> {
 
   Page<Piece> findByIdIn(List<Long> ids, Pageable pageable);
 
+  @Query(
+      "SELECT p from Piece p WHERE p.id NOT IN :pieceIds AND p.progressStatus IN :statuses AND SIZE(p.pieceLikes) = 0 ORDER BY p.createdAt ASC")
+  Page<Piece> findByIdNotInAndProgressStatusInNolikes(
+      @Param("pieceIds") List<Long> pieceIds,
+      @Param("statuses") List<ProgressStatus> statuses,
+      Pageable pageable);
+
+  @Query("SELECT p from Piece p WHERE p.progressStatus IN :statuses ORDER BY p.createdAt DESC")
+  Page<Piece> findByProgressStatusIn(
+      @Param("statuses") List<ProgressStatus> statuses, Pageable pageable);
+
   List<Piece> findByUser_Id(Long userId);
 
   @Query("SELECT p FROM Piece p WHERE p.user.id = :userId")

--- a/src/main/java/com/likelion13/artium/domain/piece/service/PieceService.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/service/PieceService.java
@@ -14,6 +14,7 @@ import com.likelion13.artium.domain.piece.dto.request.UpdatePieceRequest;
 import com.likelion13.artium.domain.piece.dto.response.PieceFeedResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceSummaryResponse;
+import com.likelion13.artium.domain.piece.entity.RecommendSortBy;
 import com.likelion13.artium.domain.piece.entity.SaveStatus;
 import com.likelion13.artium.global.page.response.PageResponse;
 
@@ -89,15 +90,17 @@ public interface PieceService {
   /**
    * 좋아요 기반 추천 작품 리스트 조회 메서드
    *
+   * @param sortBy 분류 기준 (FAVORITE : 취향 저격, NEW_STYLE : 색다른 도전)
    * @param pageable 페이징 처리값 객체
    * @return 추천 작품 리스트
    */
-  PageResponse<PieceSummaryResponse> getRecommendationPiecePage(Pageable pageable);
+  PageResponse<PieceFeedResponse> getRecommendationPiecePage(
+      RecommendSortBy sortBy, Pageable pageable);
 
   /**
    * 피드의 작품 리스트 조회 메서드
    *
-   * @param sortBy 인기순, 최신순 정렬 기준
+   * @param sortBy 인기순, 최신순 분류 기준
    * @param pageable 페이징 처리값 객체
    * @return 작품 리스트
    */

--- a/src/main/java/com/likelion13/artium/domain/piece/service/PieceServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/piece/service/PieceServiceImpl.java
@@ -4,6 +4,7 @@
 package com.likelion13.artium.domain.piece.service;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ import com.likelion13.artium.domain.piece.dto.response.PieceResponse;
 import com.likelion13.artium.domain.piece.dto.response.PieceSummaryResponse;
 import com.likelion13.artium.domain.piece.entity.Piece;
 import com.likelion13.artium.domain.piece.entity.ProgressStatus;
+import com.likelion13.artium.domain.piece.entity.RecommendSortBy;
 import com.likelion13.artium.domain.piece.entity.SaveStatus;
 import com.likelion13.artium.domain.piece.exception.PieceErrorCode;
 import com.likelion13.artium.domain.piece.mapper.PieceMapper;
@@ -36,6 +38,7 @@ import com.likelion13.artium.domain.pieceDetail.service.PieceDetailService;
 import com.likelion13.artium.domain.pieceLike.repository.PieceLikeRepository;
 import com.likelion13.artium.domain.user.entity.User;
 import com.likelion13.artium.domain.user.exception.UserErrorCode;
+import com.likelion13.artium.domain.user.repository.UserLikeRepository;
 import com.likelion13.artium.domain.user.repository.UserRepository;
 import com.likelion13.artium.domain.user.service.UserService;
 import com.likelion13.artium.global.ai.vector.VectorUtils;
@@ -64,6 +67,7 @@ public class PieceServiceImpl implements PieceService {
   private final PageMapper pageMapper;
   private final UserRepository userRepository;
   private final QdrantService qdrantService;
+  private final UserLikeRepository userLikeRepository;
 
   @Override
   public PageResponse<PieceSummaryResponse> getPiecePage(Long userId, Pageable pageable) {
@@ -307,19 +311,64 @@ public class PieceServiceImpl implements PieceService {
   }
 
   @Override
-  public PageResponse<PieceSummaryResponse> getRecommendationPiecePage(Pageable pageable) {
+  public PageResponse<PieceFeedResponse> getRecommendationPiecePage(
+      RecommendSortBy sortBy, Pageable pageable) {
     Long userId = userService.getCurrentUser().getId();
 
-    Pageable sortedPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+    List<Long> recommendPieceIds = recommendPieceIds(userId, pageable.getPageSize());
+    Page<PieceFeedResponse> page;
 
-    List<Long> recommendPieceIds = recommendPieceIds(userId, 50);
+    log.info("추천 작품 아이디 리스트 - recommendPieceIds : {} ", recommendPieceIds);
+    switch (sortBy) {
+      case FAVORITE:
+        page =
+            pieceRepository
+                .findByIdIn(recommendPieceIds, pageable)
+                .map(
+                    piece ->
+                        pieceMapper.toPieceFeedResponse(
+                            piece,
+                            userLikeRepository.existsByLiker_IdAndLiked_Id(
+                                userId, piece.getUser().getId())));
+        log.info("관심사 기반 취향 저격 작품 리스트 조회 성공");
+        break;
+      case NEW_STYLE:
+        recommendPieceIds = new ArrayList<>(recommendPieceIds);
+        List<Long> myPieceIds =
+            pieceRepository.findByUser_Id(userId).stream().map(Piece::getId).toList();
+        if (!myPieceIds.isEmpty()) {
+          recommendPieceIds.addAll(myPieceIds);
+        }
+        List<ProgressStatus> statuses =
+            new ArrayList<>(Arrays.asList(ProgressStatus.REGISTERED, ProgressStatus.ON_DISPLAY));
+        if (recommendPieceIds.isEmpty()) {
+          page =
+              pieceRepository
+                  .findByProgressStatusIn(statuses, pageable)
+                  .map(
+                      piece ->
+                          pieceMapper.toPieceFeedResponse(
+                              piece,
+                              userLikeRepository.existsByLiker_IdAndLiked_Id(
+                                  userId, piece.getUser().getId())));
+        } else {
+          page =
+              pieceRepository
+                  .findByIdNotInAndProgressStatusInNolikes(recommendPieceIds, statuses, pageable)
+                  .map(
+                      piece ->
+                          pieceMapper.toPieceFeedResponse(
+                              piece,
+                              userLikeRepository.existsByLiker_IdAndLiked_Id(
+                                  userId, piece.getUser().getId())));
+        }
+        log.info("색다른 도전 작품 리스트 조회 성공");
+        break;
+      default:
+        throw new CustomException(PieceErrorCode.INVALID_SORT_TYPE);
+    }
 
-    Page<PieceSummaryResponse> page =
-        pieceRepository
-            .findByIdIn(recommendPieceIds, sortedPageable)
-            .map(pieceMapper::toPieceSummaryResponse);
-
-    return pageMapper.toPiecePageResponse(page);
+    return pageMapper.toPieceFeedPageResponse(page);
   }
 
   @Override
@@ -362,19 +411,11 @@ public class PieceServiceImpl implements PieceService {
   private List<Long> recommendPieceIds(Long userId, int topN) {
     int limit = (topN < 0) ? 50 : topN;
 
-    List<Long> likeIds = pieceLikeRepository.findIdsByUser_Id(userId);
+    float[] userVector =
+        VectorUtils.normalize(qdrantService.retrieveVectorById(userId, CollectionName.USER));
 
-    if (likeIds == null || likeIds.isEmpty()) {
-      return List.of();
-    }
-
-    List<float[]> likeVecs = qdrantService.retrieveVectorsByIds(likeIds, CollectionName.PIECE);
-    float[] userVector = VectorUtils.normalize(VectorUtils.mean(likeVecs));
-
-    List<Long> excludeIds = new ArrayList<>(likeIds);
-    List<Long> myPieceIds =
+    List<Long> excludeIds =
         pieceRepository.findByUser_Id(userId).stream().map(Piece::getId).toList();
-    excludeIds.addAll(myPieceIds);
 
     List<Map<String, Object>> result =
         qdrantService.search(userVector, limit, excludeIds, CollectionName.PIECE);
@@ -394,7 +435,7 @@ public class PieceServiceImpl implements PieceService {
             .filter(Objects::nonNull)
             .map(p -> ((Number) p.get("pieceId")).longValue())
             .toList();
-
+    log.info("추천 기반 후보 작품 아이디 리스트 - candidateIds : {} ", candidateIds);
     Map<Long, Integer> pos = new HashMap<>();
     for (int i = 0; i < candidateIds.size(); i++) pos.put(candidateIds.get(i), i);
 

--- a/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
+++ b/src/main/java/com/likelion13/artium/domain/user/controller/UserControllerImpl.java
@@ -163,7 +163,7 @@ public class UserControllerImpl implements UserController {
       @RequestParam List<FormatPreference> formatPreferences) {
     if (themePreferences == null
         || themePreferences.isEmpty()
-        || themePreferences.size() > 5
+        || themePreferences.size() > 3
         || moodPreferences == null
         || moodPreferences.isEmpty()
         || moodPreferences.size() > 5

--- a/src/main/java/com/likelion13/artium/global/ai/vector/VectorUtils.java
+++ b/src/main/java/com/likelion13/artium/global/ai/vector/VectorUtils.java
@@ -39,4 +39,16 @@ public class VectorUtils {
     for (int i = 0; i < v.length; i++) out[i] = (float) (v[i] / norm);
     return out;
   }
+
+  public static float[] scale(float[] v, double w) {
+    float[] out = new float[v.length];
+    for (int i = 0; i < v.length; i++) out[i] = (float) (v[i] * w);
+    return out;
+  }
+
+  public static float[] addScaled(float[] a, float[] b, double wa, double wb) {
+    float[] out = new float[a.length];
+    for (int i = 0; i < a.length; i++) out[i] = (float) (a[i] * wa + b[i] * wb);
+    return out;
+  }
 }

--- a/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantServiceImpl.java
+++ b/src/main/java/com/likelion13/artium/global/qdrant/service/QdrantServiceImpl.java
@@ -204,7 +204,7 @@ public class QdrantServiceImpl implements QdrantService {
     body.put("limit", limit);
     body.put("with_payload", true);
     body.put("params", params);
-    body.put("score_threshold", 0.30);
+    body.put("score_threshold", 0.20);
     if (!must.isEmpty() || !mustNot.isEmpty()) body.put("filter", filter);
 
     Map resp =


### PR DESCRIPTION
## ✨ 새로운 기능
- 어떤 기능을 추가했나요? : 
- 내 취향 저격 작품(관심사 기반) 리스트,  색다른 도전 작품 리스트(보류) API 개발 (AI)
- 해당 작품이 전시 중인지 반환하는 API (화면 참고)

- 사용자에게 어떤 이점을 주나요? : 내 관심사를 기반으로한 작품을 추천함으로써 흥미 유도, 작품의 전시 현황을 알아보면서 서비스를 편하게 이용

## 🛠 개발 상세
- 구현 방식 요약 : 요청 사용자의 관심사 벡터를 추출하여 이를 기반으로 작품의 벡터와 비교하며 추천 작품 리스트를 추출

## 🧩 추가 고려사항
- 데이터를 추가하면서 임베딩 temperature, topP 값 조정 및 추천 유사도 값 조정 필요

## 🔗 관련 문서 / 이슈
- issue: #38 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 추천 작품 API가 피드 형식으로 반환되며 정렬 옵션(FAVORITE, NEW_STYLE)을 지원합니다.
  - 작품 응답에 전시 요약 정보가 추가되어, 전시 중인 경우 해당 전시를 함께 확인할 수 있습니다.
- Refactor
  - 전시–작품 연결 구조를 개선하여 한 작품의 다중 전시 표시를 안정적으로 지원하고, 추천 로직을 고도화해 개인화 품질을 향상했습니다.
- Chores
  - 사용자 선호 설정에서 테마 선택 가능 최대 개수가 5개에서 3개로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->